### PR TITLE
Fix texts into localized string script error when passing non-string type

### DIFF
--- a/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
+++ b/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
@@ -21,6 +21,7 @@ TRACE_1("Texts",_texts);
 // Compile texts into one localized string
 private _text = "";
 {
+    _x = str _x;
     if (_x select [0, 4] == "STR_") then {
         _x = localize _x;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #324 