### PR TITLE
Fix full refresh box contents duplicating items

### DIFF
--- a/addons/armory/XEH_postInitClient.sqf
+++ b/addons/armory/XEH_postInitClient.sqf
@@ -10,9 +10,28 @@ if (!hasInterface) exitWith {};
 
 [QEGVAR(apollo,lockerActionDone), {
     params ["_player"];
-    // Only update if still open
-    if (!isNull (_player getVariable [QGVAR(object), objNull])) then {
-        TRACE_1("Stash force update",_player);
-        [call FUNC(getBoxContents)] call FUNC(updateData);
-    };
+
+    TRACE_1("Waiting for stashing to stop for full refresh",CBA_missionTime);
+    [{
+        params ["_player"];
+        CBA_missionTime > (_player getVariable [QGVAR(lastStashTime), 0]) + 1
+    }, {
+        params ["_player"];
+        // Only update if still open
+        if (!isNull (_player getVariable [QGVAR(object), objNull])) then {
+            TRACE_1("Stash force update",_player);
+            private _boxContents = call FUNC(getBoxContents);
+
+            private _subtractOnFullRefresh = ACE_player getVariable [QGVAR(subtractOnFullRefresh), []];
+            {
+                _x params ["_selectedItem", "_selectedAmount"];
+                TRACE_2("Subtracting on force update",_selectedItem,_selectedAmount);
+                _boxContents = [_boxContents, _selectedItem, _selectedAmount] call FUNC(subtractData);
+                _subtractOnFullRefresh deleteAt _forEachIndex;
+            } forEach [];
+            TRACE_1("Finish subtract on full refresh",_subtractOnFullRefresh);
+
+            [_boxContents] call FUNC(updateData);
+        };
+    }, _player, 1] call CBA_fnc_waitUntilAndExecute;
 }] call CBA_fnc_addEventHandler;

--- a/addons/armory/functions/fnc_processAction.sqf
+++ b/addons/armory/functions/fnc_processAction.sqf
@@ -107,4 +107,11 @@ if (GVAR(system) == 1) then {
     // Update list (subtract only, due to usage of CBA functions a callback event is used for full refresh when done)
     private _newArmoryData = [GVAR(armoryData), _selectedItem, _selectedAmount] call FUNC(subtractData);
     [_newArmoryData] call FUNC(updateData);
+
+    if (_type == "stash") then {
+        private _subtractOnFullRefresh = ACE_player getVariable [QGVAR(subtractOnFullRefresh), []];
+        _subtractOnFullRefresh pushBack [_selectedItem, _selectedAmount];
+        ACE_player setVariable [QGVAR(lastStashTime), CBA_missionTime];
+        TRACE_1("Setting subtract on full refresh",_subtractOnFullRefresh);
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #321
- Add delay to full refresh of box contents until player stops stashing for a second