### PR TITLE
Fix strings being stringified a second time in textsIntoLocalizedString

### DIFF
--- a/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
+++ b/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
@@ -21,10 +21,14 @@ TRACE_1("Texts",_texts);
 // Compile texts into one localized string
 private _text = "";
 {
-    _x = str _x;
-    if (_x select [0, 4] == "STR_") then {
-        _x = localize _x;
+    if (_x isEqualType 0) then {
+        _x = str _x;
+    } else {
+        if (_x select [0, 4] == "STR_") then {
+            _x = localize _x;
+        };
     };
+
     _text = [_text, _x] joinString "";
 } forEach _texts;
 

--- a/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
+++ b/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
@@ -21,12 +21,12 @@ TRACE_1("Texts",_texts);
 // Compile texts into one localized string
 private _text = "";
 {
-    if (_x isEqualType 0) then {
-        _x = str _x;
-    } else {
+    if (_x isEqualType "") then {
         if (_x select [0, 4] == "STR_") then {
             _x = localize _x;
         };
+    } else {
+        _x = str _x;
     };
 
     _text = [_text, _x] joinString "";


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an issue where strings name would appear with double quote instead of being localized after finishing a course.
