### PR TITLE
Fix Insignia enabled initialization order

### DIFF
--- a/addons/cba_settings/README.md
+++ b/addons/cba_settings/README.md
@@ -2,8 +2,6 @@
 
 CBA Settings Static Addon Userconfig. Does not conform to TAC Mods naming, made from [template](https://github.com/CBATeam/CBA_A3/tree/master/template/cba_settings_userconfig) provided by CBA.
 
-Only built correctly using `make.py`, `build.py` does not respect `$PBOPREFIX$`!
-
 ### Authors
 
 - [CBA Team](http://github.com/CBATeam/CBA_A3)

--- a/addons/insignia/CfgEventHandlers.hpp
+++ b/addons/insignia/CfgEventHandlers.hpp
@@ -10,26 +10,8 @@ class Extended_PreInit_EventHandlers {
     };
 };
 
-class Extended_InitPost_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            clientInit = QUOTE(_this call FUNC(setInsignia));
-        };
-    };
-};
-
-class Extended_Take_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            clientTake = QUOTE(_this call FUNC(setInsignia));
-        };
-    };
-};
-
-class Extended_InventoryOpened_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            clientInventoryOpened = QUOTE(_this call FUNC(getInsignia));
-        };
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        clientInit = QUOTE(call COMPILE_FILE(XEH_clientInit));
     };
 };

--- a/addons/insignia/XEH_clientInit.sqf
+++ b/addons/insignia/XEH_clientInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+// Exit on Headless
+if (!hasInterface) exitWith {};
+
+["CAManBase", "Take", FUNC(setInsignia)] call CBA_fnc_addClassEventHandler;
+["CAManBase", "InventoryOpened", FUNC(getInsignia)] call CBA_fnc_addClassEventHandler;

--- a/addons/insignia/functions/fnc_getInsignia.sqf
+++ b/addons/insignia/functions/fnc_getInsignia.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [unit] call tac_insignia_fnc_getInsignia;
+ * [unit] call tac_insignia_fnc_getInsignia
  *
  * Public: No
  */

--- a/addons/insignia/functions/fnc_setInsignia.sqf
+++ b/addons/insignia/functions/fnc_setInsignia.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_2("Trying to add insignia",_unit,GVAR(enabled));
 
 // Don't exit if insignia already set, BIS_fnc_getUnitInsignia will return the last set insignia even if it's currently not visible
 if (!GVAR(enabled) || {!local _unit} || {_unit != player}) exitWith {};

--- a/addons/insignia/functions/fnc_setInsignia.sqf
+++ b/addons/insignia/functions/fnc_setInsignia.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [unit] call tac_insignia_fnc_setInsignia;
+ * [unit] call tac_insignia_fnc_setInsignia
  *
  * Public: No
  */
@@ -22,6 +22,9 @@ TRACE_2("Trying to add insignia",_unit,GVAR(enabled));
 if (!GVAR(enabled) || {!local _unit} || {_unit != player}) exitWith {};
 
 private _insignia = _unit getVariable [QGVAR(activeInsignia), QGVAR(logoStitch)];
+
+// Setting insignia fails even if not actually visible (uniform dropped and picked up), so reset manually
+[_unit, ""] call BIS_fnc_setUnitInsignia;
 [_unit, _insignia] call BIS_fnc_setUnitInsignia;
 
 TRACE_2("Insignia added",_unit,_insignia);

--- a/addons/insignia/initSettings.sqf
+++ b/addons/insignia/initSettings.sqf
@@ -4,5 +4,6 @@
     [LSTRING(Enabled), LSTRING(EnabledDesc)],
     format ["TAC %1", localize "str_a3_rscdisplaywelcome_expa_parc_list6_title"],
     true,
-    true
+    true,
+    {[ACE_player] call FUNC(setInsignia)}
 ] call CBA_Settings_fnc_init;

--- a/addons/insignia/script_component.hpp
+++ b/addons/insignia/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Insignia
 #include "\x\tac\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_INSIGNIA

--- a/addons/insignia/script_component.hpp
+++ b/addons/insignia/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Insignia
 #include "\x\tac\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_INSIGNIA

--- a/tools/build.py
+++ b/tools/build.py
@@ -70,13 +70,14 @@ def main():
         print("# Making {} ...".format(p))
 
         try:
-            subprocess.check_output([
-                "makepbo",
-                "-NUP",
-                "-@={}\\{}\\addons\\{}".format(MAINPREFIX,PREFIX.rstrip("_"),p),
-                p,
-                "{}{}.pbo".format(PREFIX,p)
-            ], stderr=subprocess.STDOUT)
+            with open(os.path.join(p, "$PBOPREFIX$")) as pboprefix:
+                subprocess.check_output([
+                    "makepbo",
+                    "-NUP",
+                    "-@={}".format(pboprefix.read().strip("\n")),
+                    p,
+                    "{}{}.pbo".format(PREFIX,p)
+                ], stderr=subprocess.STDOUT)
         except:
             failed += 1
             print("  Failed to make {}.".format(p))


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #340 
- Use CBA Setting Changed for insignia application (runs after initialized correctly)
- Make CBA Settings component build correctly with `build.py` as well