### PR TITLE
Update NVG settings for ACE 3.12.2

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -36,8 +36,9 @@ ace_mk6mortar_useAmmoHandling = true;
 
 ace_nametags_showPlayerRanks = false;
 
-ace_nightvision_aimDownSightsBlur = 0.5;
+ace_nightvision_aimDownSightsBlur = 0.4;
 ace_nightvision_effectScaling = 0.5;
+ace_nightvision_noiseScaling = 0.5;
 
 ace_overheating_unJamOnreload = true;
 

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -8,8 +8,8 @@
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.78
-#define REQUIRED_CBA_VERSION {3,5,0}
+#define REQUIRED_VERSION 1.82
+#define REQUIRED_CBA_VERSION {3,7,0}
 #define REQUIRED_ACE_VERSION {3,12,2}
 
 #ifdef COMPONENT_BEAUTIFIED

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -10,7 +10,7 @@
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.78
 #define REQUIRED_CBA_VERSION {3,5,0}
-#define REQUIRED_ACE_VERSION {3,10,1}
+#define REQUIRED_ACE_VERSION {3,12,2}
 
 #ifdef COMPONENT_BEAUTIFIED
     #define COMPONENT_NAME QUOTE(TAC - COMPONENT_BEAUTIFIED)


### PR DESCRIPTION
**When merged this pull request will:**
- Use new setting `noiseScaling` and `fogScaling` (separated from `effectScaling`)
- Leave `fogScaling` at default (`1`) and balance others

**Requires CBA 3.7.0!**