### PR TITLE
Update NVG Settings for new ACE Update

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -36,8 +36,9 @@ ace_mk6mortar_useAmmoHandling = true;
 
 ace_nametags_showPlayerRanks = false;
 
-ace_nightvision_aimDownSightsBlur = 0.5;
+ace_nightvision_aimDownSightsBlur = 0.4;
 ace_nightvision_effectScaling = 0.5;
+ace_nightvision_noiseScaling = 0.5;
 
 ace_overheating_unJamOnreload = true;
 


### PR DESCRIPTION
- Adds the Noise Scaling setting for the new ACE Update
- Reduced ADS Blur by a tick, due to the issue of the entire screen blurring. At 0.4, it's slightly better while still making ADS not always desirable due to the blur