### PR TITLE
Fix error line numbers being wrong

### DIFF
--- a/addons/air_security/functions/fnc_canSecure.sqf
+++ b/addons/air_security/functions/fnc_canSecure.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the crew of the vehicle can be Secured.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle", "_unit"];
 

--- a/addons/air_security/functions/fnc_canUnsecure.sqf
+++ b/addons/air_security/functions/fnc_canUnsecure.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the crew of the vehicle can be Unsecured.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle", "_unit"];
 

--- a/addons/air_security/functions/fnc_setSecurity.sqf
+++ b/addons/air_security/functions/fnc_setSecurity.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Toggles vehicle crew security.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle"];
 

--- a/addons/apollo/functions/fnc_endMissionError.sqf
+++ b/addons/apollo/functions/fnc_endMissionError.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Ends mission with error message on client.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_errorMessage"];
 

--- a/addons/apollo/functions/fnc_handleDisconnect.sqf
+++ b/addons/apollo/functions/fnc_handleDisconnect.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles save and corpse removal on disconnect.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit", "", "_uid"];
 TRACE_1("Handle Disconnect",_this);

--- a/addons/apollo/functions/fnc_handleKilled.sqf
+++ b/addons/apollo/functions/fnc_handleKilled.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles killed event (mark in backend for fresh inventory).
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player", "_killer"];
 TRACE_1("Handle Killed",_this);

--- a/addons/apollo/functions/fnc_handleRespawn.sqf
+++ b/addons/apollo/functions/fnc_handleRespawn.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles respawn event (mark in backend for fresh inventory).
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player", "_corpse"];
 TRACE_1("Handle Respawn",_this);

--- a/addons/apollo/functions/fnc_invokeJavaMethod.sqf
+++ b/addons/apollo/functions/fnc_invokeJavaMethod.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Invokes Java code through JNI extension with XML marshalling and returns the return value from extension.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_method"];
 

--- a/addons/apollo/functions/fnc_lockerAction.sqf
+++ b/addons/apollo/functions/fnc_lockerAction.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Parses locker action through extension.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player", "_type", "_container", "_itemClass", "_quantity"];
 

--- a/addons/apollo/functions/fnc_playerLoadClient.sqf
+++ b/addons/apollo/functions/fnc_playerLoadClient.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Loads player using ApolloClient extension.
@@ -15,7 +16,6 @@
  * Public: No
  */
 //#define DEBUG_MODE_FULL
-#include "script_component.hpp"
 
 params ["_player", "_loadType"];
 

--- a/addons/apollo/functions/fnc_playerSaveClient.sqf
+++ b/addons/apollo/functions/fnc_playerSaveClient.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles loadout change and periodic saves. Requests a save of the player after a delay.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player", "", ["_periodic", false]];
 TRACE_2("Player Save Client",_player,_periodic);

--- a/addons/apollo/functions/fnc_playerSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_playerSingletonSave.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Saves a player object and necessary variables.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player", "_uid", "_type"];
 

--- a/addons/apollo/functions/fnc_vehicleLoad.sqf
+++ b/addons/apollo/functions/fnc_vehicleLoad.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Loads vehicles.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _retrieveVehicles = ["retrieveAllVehicles"] call FUNC(invokeJavaMethod);
 

--- a/addons/apollo/functions/fnc_vehicleSaveServer.sqf
+++ b/addons/apollo/functions/fnc_vehicleSaveServer.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Saves vehicles.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Make safe copy in case of new vehicles during this save round
 private _vehList = +GVAR(vehiclesList);

--- a/addons/apollo/functions/fnc_vehicleSingletonLoad.sqf
+++ b/addons/apollo/functions/fnc_vehicleSingletonLoad.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Loads a single vehicle.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicleID"];
 

--- a/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Saves a single vehicle.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicleObject"];
 

--- a/addons/armory/functions/fnc_addItems.sqf
+++ b/addons/armory/functions/fnc_addItems.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds items to vanilla Armory system.
@@ -19,7 +20,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 params [
     ["_object", objNull, [objNull]],

--- a/addons/armory/functions/fnc_canAddArmory.sqf
+++ b/addons/armory/functions/fnc_canAddArmory.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if armory can be added to the object (object has inventory).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 

--- a/addons/armory/functions/fnc_canOpenArmory.sqf
+++ b/addons/armory/functions/fnc_canOpenArmory.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if armory can be opened (is not in use by someone else).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 

--- a/addons/armory/functions/fnc_closeArmory.sqf
+++ b/addons/armory/functions/fnc_closeArmory.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Close Armory and clean up.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Allow others to use the object's Armory
 private _object = ACE_player getVariable [QGVAR(object), objNull];

--- a/addons/armory/functions/fnc_dialogControl.sqf
+++ b/addons/armory/functions/fnc_dialogControl.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Overall menu manipulation.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_requestedMenu"];
 

--- a/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
+++ b/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets up amount selection dropdown.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _quantity = CTRL(NLIST) lnbData [lnbCurSelRow NLIST, 2];
 TRACE_1("Amount of selected item",_quantity);

--- a/addons/armory/functions/fnc_dialogControl_back.sqf
+++ b/addons/armory/functions/fnc_dialogControl_back.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Goes back to menu or exits Armory.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_type"];
 

--- a/addons/armory/functions/fnc_dialogControl_list.sqf
+++ b/addons/armory/functions/fnc_dialogControl_list.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets up requested list and dropdown.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_selectedCategory"];
 GVAR(selectedCategory) = _selectedCategory; // For FUNC(dialogControl_takestash)

--- a/addons/armory/functions/fnc_dialogControl_main.sqf
+++ b/addons/armory/functions/fnc_dialogControl_main.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets up main menu.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_show"];
 

--- a/addons/armory/functions/fnc_dialogControl_populateList.sqf
+++ b/addons/armory/functions/fnc_dialogControl_populateList.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Populates lists.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_armoryData"];
 

--- a/addons/armory/functions/fnc_dialogControl_takestash.sqf
+++ b/addons/armory/functions/fnc_dialogControl_takestash.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Shows Take/Stash buttons.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Hide take/stash if quantity of dropdown amount selection is not set
 if (lbText [DROPDOWNAMOUNT, lbCurSel CTRL(DROPDOWNAMOUNT)] == "") exitWith {

--- a/addons/armory/functions/fnc_extractSubCategories.sqf
+++ b/addons/armory/functions/fnc_extractSubCategories.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Extracts sub-categories from Armory Data.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_armoryData", "_compatible"];
 

--- a/addons/armory/functions/fnc_getBoxContents.sqf
+++ b/addons/armory/functions/fnc_getBoxContents.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Returns contents of a box.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _object = ACE_player getVariable [QGVAR(object), objNull];
 

--- a/addons/armory/functions/fnc_getDataChronos.sqf
+++ b/addons/armory/functions/fnc_getDataChronos.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Gets data from Apollo Client / Athena (Chronos).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_selectedCategory"];
 

--- a/addons/armory/functions/fnc_getDataVanilla.sqf
+++ b/addons/armory/functions/fnc_getDataVanilla.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Gets preset Armory data.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_selectedCategory"];
 

--- a/addons/armory/functions/fnc_init.sqf
+++ b/addons/armory/functions/fnc_init.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds the Armory action to an Object and handles the GUI initialization.
@@ -13,7 +14,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 params [["_object", this]];
 

--- a/addons/armory/functions/fnc_isCompatible.sqf
+++ b/addons/armory/functions/fnc_isCompatible.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if magazine or attachment is compatible with any weapon carried by player.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_itemClass"];
 

--- a/addons/armory/functions/fnc_openArmory.sqf
+++ b/addons/armory/functions/fnc_openArmory.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Open Armory on an object.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 

--- a/addons/armory/functions/fnc_processAction.sqf
+++ b/addons/armory/functions/fnc_processAction.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Processes performed action and modifies Vanilla data or sends data back to Apollo (Chronos).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_type"];
 

--- a/addons/armory/functions/fnc_subtractData.sqf
+++ b/addons/armory/functions/fnc_subtractData.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Subtracts quantity of an item or removes it completely (for in-list handling).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_armoryData", "_selectedItem", "_selectedAmount"];
 

--- a/addons/armory/functions/fnc_updateData.sqf
+++ b/addons/armory/functions/fnc_updateData.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Updates Armory Data in currently open screen.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_newArmoryData"];
 

--- a/addons/bodybag/functions/fnc_moveInventory.sqf
+++ b/addons/bodybag/functions/fnc_moveInventory.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Puts killed unit's inventory into the body bag.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit", "_bodybag"];
 

--- a/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Saves dropped weapons to a variable on the unit. Workaround for restoring dropped weapons which get deleted with deleteVehicle.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit"];
 

--- a/addons/heavylifter/functions/fnc_canAttach.sqf
+++ b/addons/heavylifter/functions/fnc_canAttach.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the heavy duty hooks can be Attached.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle"];
 

--- a/addons/heavylifter/functions/fnc_canDetach.sqf
+++ b/addons/heavylifter/functions/fnc_canDetach.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the heavy duty hooks can be Detached.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle"];
 

--- a/addons/heavylifter/functions/fnc_exportConfig.sqf
+++ b/addons/heavylifter/functions/fnc_exportConfig.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: BaerMitUmlaut, 654wak654, Jonpas
  * Generates the CfgVehicles config for heavy lifter compatibility.
@@ -15,7 +16,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 #define HELPER_CENTER_HEIGHT 1.32
 

--- a/addons/heavylifter/functions/fnc_prepare.sqf
+++ b/addons/heavylifter/functions/fnc_prepare.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Prepares the vehicle for heavy lifting.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private ["_attachPos", "_vehiclePosOffsetWorld", "_vehiclePosOffset", "_vehicleVectorDirAndUp", "_helper"];
 params ["_vehicle"];

--- a/addons/heavylifter/functions/fnc_progress.sqf
+++ b/addons/heavylifter/functions/fnc_progress.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Starts Attach or Detach process.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle"];
 

--- a/addons/heavylifter/functions/fnc_unprepare.sqf
+++ b/addons/heavylifter/functions/fnc_unprepare.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Sets the vehicle back to operational state.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_targetVehicle"];
 

--- a/addons/insignia/functions/fnc_getInsignia.sqf
+++ b/addons/insignia/functions/fnc_getInsignia.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Gets insignia from a player if it's actual player (and not remote controlled or AI).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit"];
 

--- a/addons/insignia/functions/fnc_setInsignia.sqf
+++ b/addons/insignia/functions/fnc_setInsignia.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds insignia to a player if it's actual player (and not remote controlled or AI).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit"];
 TRACE_2("Trying to add insignia",_unit,GVAR(enabled));

--- a/addons/misc/functions/fnc_toggleAlarm.sqf
+++ b/addons/misc/functions/fnc_toggleAlarm.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles the Alarm switching.
@@ -14,7 +15,6 @@
  * [<arg0>, [<arg1>]] call TAC_Misc_fnc_toggleAlarm;
  * [<arg0>, [<arg1.0>, <arg1.1>, <arg1.2>], "Sound_Alarm"] call TAC_Misc_fnc_toggleAlarm;
  */
-#include "script_component.hpp"
 
 params ["_button", "_speakers", ["_soundType", "Sound_Alarm"]];
 

--- a/addons/mission_autotest/functions/fnc_autotest.sqf
+++ b/addons/mission_autotest/functions/fnc_autotest.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Performs overall autotest and logs the results.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _ctrlListbox = _this controlsGroupCtrl CTRL_PICTURE;
 _ctrlListbox lnbSetColumnsPos [FINDINGS_COLUMN_SIZE]; // Fix entries positioning

--- a/addons/mission_autotest/functions/fnc_testAIAmount.sqf
+++ b/addons/mission_autotest/functions/fnc_testAIAmount.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests AI amount.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _aiAmount = count (allUnits - playableUnits);
 

--- a/addons/mission_autotest/functions/fnc_testAIPosession.sqf
+++ b/addons/mission_autotest/functions/fnc_testAIPosession.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests disabled AI value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["disabledAI", 0];
 

--- a/addons/mission_autotest/functions/fnc_testApollo.sqf
+++ b/addons/mission_autotest/functions/fnc_testApollo.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests Apollo setting value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 if !(["tac_apollo"] call ACEFUNC(common,isModLoaded)) exitWith {
     (_this controlsGroupCtrl CTRL_VALUE) ctrlSetText (localize LSTRING(NotLoaded));

--- a/addons/mission_autotest/functions/fnc_testAuthor.sqf
+++ b/addons/mission_autotest/functions/fnc_testAuthor.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests author value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["author", ""];
 

--- a/addons/mission_autotest/functions/fnc_testDebugConsole.sqf
+++ b/addons/mission_autotest/functions/fnc_testDebugConsole.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests debug console availability.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["enableDebugConsole", 0];
 

--- a/addons/mission_autotest/functions/fnc_testDescription.sqf
+++ b/addons/mission_autotest/functions/fnc_testDescription.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests mission description value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["onLoadMission", ""];
 if (_value == "") then {

--- a/addons/mission_autotest/functions/fnc_testGameType.sqf
+++ b/addons/mission_autotest/functions/fnc_testGameType.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests mission game type value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getText (missionConfigFile >> "Header" >> "gameType");
 if (_value == "") then {

--- a/addons/mission_autotest/functions/fnc_testGroupSizes.sqf
+++ b/addons/mission_autotest/functions/fnc_testGroupSizes.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests group sizes of sides (288 groups per side limit).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _findings = [];
 {

--- a/addons/mission_autotest/functions/fnc_testHCAmount.sqf
+++ b/addons/mission_autotest/functions/fnc_testHCAmount.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests headless clients presence and their playability.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _hc = (all3DENEntities select 3) select {_x isKindOf "HeadlessClient_F"};
 private _hcAmount = count _hc;

--- a/addons/mission_autotest/functions/fnc_testInit.sqf
+++ b/addons/mission_autotest/functions/fnc_testInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests init fields of objects.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _findings = [];
 {

--- a/addons/mission_autotest/functions/fnc_testMaxPlayers.sqf
+++ b/addons/mission_autotest/functions/fnc_testMaxPlayers.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests maximum players value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _config = missionConfigFile >> "Header" >> "maxPlayers";
 private _value = getNumber _config; // Returns 0 even if not set

--- a/addons/mission_autotest/functions/fnc_testMinPlayers.sqf
+++ b/addons/mission_autotest/functions/fnc_testMinPlayers.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests minimum players value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _config = missionConfigFile >> "Header" >> "minPlayers";
 private _value = getNumber _config; // Returns 0 even if not set

--- a/addons/mission_autotest/functions/fnc_testName.sqf
+++ b/addons/mission_autotest/functions/fnc_testName.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: TMF Team, Jonpas
  * Tests mission name value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["onLoadName", ""];
 if (_value == "") then {

--- a/addons/mission_autotest/functions/fnc_testRespawnButton.sqf
+++ b/addons/mission_autotest/functions/fnc_testRespawnButton.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests respawn button value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["respawnButton", 1];
 

--- a/addons/mission_autotest/functions/fnc_testRespawnDelay.sqf
+++ b/addons/mission_autotest/functions/fnc_testRespawnDelay.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests respawn delay value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["respawnDelay", 0];
 

--- a/addons/mission_autotest/functions/fnc_testRespawnDialog.sqf
+++ b/addons/mission_autotest/functions/fnc_testRespawnDialog.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests respawn dialog value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["respawnDialog", 1];
 

--- a/addons/mission_autotest/functions/fnc_testRespawnMode.sqf
+++ b/addons/mission_autotest/functions/fnc_testRespawnMode.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests respawn mode value.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["respawn", 0];
 

--- a/addons/mission_autotest/functions/fnc_testTargetDebug.sqf
+++ b/addons/mission_autotest/functions/fnc_testTargetDebug.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Tests CBA's target debug availability.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _value = getMissionConfigValue ["enableTargetDebug", 0];
 

--- a/addons/radios/functions/fnc_addRadioTrackActions.sqf
+++ b/addons/radios/functions/fnc_addRadioTrackActions.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds radio tracks actions.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle"];
 

--- a/addons/radios/functions/fnc_canPlayRadio.sqf
+++ b/addons/radios/functions/fnc_canPlayRadio.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if vehicle or static radio can played.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle", "_unit"];
 

--- a/addons/radios/functions/fnc_canStopRadio.sqf
+++ b/addons/radios/functions/fnc_canStopRadio.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if vehicle radio can be stopped.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle", "_unit"];
 

--- a/addons/radios/functions/fnc_changeVolume.sqf
+++ b/addons/radios/functions/fnc_changeVolume.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets current radio volume.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_volume", "_vehicle"];
 

--- a/addons/radios/functions/fnc_getRadioTracks.sqf
+++ b/addons/radios/functions/fnc_getRadioTracks.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Gets radio tracks classnames from config.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private _tracks = ("true" configClasses (configFile >> "CfgSounds")) apply {toLower (configName _x)};
 _tracks = _tracks select {_x find QUOTE(ADDON) != -1 && {_x find "_quiet" == -1} && {_x find "_loud" == -1}};

--- a/addons/radios/functions/fnc_playRadio.sqf
+++ b/addons/radios/functions/fnc_playRadio.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Attaches a radio to a vehicle and starts playing the selected track on it.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_vehicle", "_track"];
 

--- a/addons/radios/functions/fnc_stopRadio.sqf
+++ b/addons/radios/functions/fnc_stopRadio.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Stops playing music in the vehicle and removes the radio.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 private ["_radio"];
 params ["_vehicle"];

--- a/addons/ratelmarker/functions/fnc_canUseMarkerMenu.sqf
+++ b/addons/ratelmarker/functions/fnc_canUseMarkerMenu.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if RATEL Marker menu can be used.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 if (!isNil {uiNamespace getVariable QGVAR(menuDisplay)}) exitWith {};
 

--- a/addons/ratelmarker/functions/fnc_createMarker.sqf
+++ b/addons/ratelmarker/functions/fnc_createMarker.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Creates a marker at coordiantes and adds animation on map open.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_pos"];
 

--- a/addons/ratelmarker/functions/fnc_createMarkerMenu.sqf
+++ b/addons/ratelmarker/functions/fnc_createMarkerMenu.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Opens coordinate input display.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Has to be display to allow movement
 private _display = (findDisplay 46) createDisplay QGVAR(menu);

--- a/addons/ratelmarker/functions/fnc_prepareMarker.sqf
+++ b/addons/ratelmarker/functions/fnc_prepareMarker.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: DaC, Jonpas
  * Prepares a marker based on input and executes it on pilot and turrets.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 disableSerialization;
 

--- a/addons/shootingrange/functions/fnc_addConfigCountdownTimes.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigCountdownTimes.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds shooting range countdown times configuration child interactions to a controller.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controller", "_controllers", "_countdownTimes", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_addConfigDurations.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigDurations.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds shooting range durations configuration child interactions to a controller.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controller", "_controllers", "_durations", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_addConfigPauseDurations.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigPauseDurations.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds shooting range pause durations configuration child interactions to a controller.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controller", "_controllers", "_pauseDurations", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_addConfigTargetAmounts.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigTargetAmounts.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds shooting range target amounts configuration child interactions to a controller.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controller", "_controllers", "_targetAmounts", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_animateTarget.sqf
+++ b/addons/shootingrange/functions/fnc_animateTarget.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Animates a target.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_target", "_state"];
 

--- a/addons/shootingrange/functions/fnc_canActivateTrigger.sqf
+++ b/addons/shootingrange/functions/fnc_canActivateTrigger.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if a trigger can be activated.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_controller", "_target"];
 

--- a/addons/shootingrange/functions/fnc_checkConfig.sqf
+++ b/addons/shootingrange/functions/fnc_checkConfig.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks current shooting range configuration
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_controller", "_name", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_configure.sqf
+++ b/addons/shootingrange/functions/fnc_configure.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Configures shooting range on run-time, to modify (eg. randomize targets) range dynamically. Should be called from started event locally.
@@ -19,7 +20,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 params [
     ["_controller", objNull, [objNull] ],

--- a/addons/shootingrange/functions/fnc_create.sqf
+++ b/addons/shootingrange/functions/fnc_create.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Creates a shooting range. Local effect, must be called on each client machine.
@@ -31,7 +32,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 params [
     ["_name", "", [""] ],

--- a/addons/shootingrange/functions/fnc_getTargetAnimations.sqf
+++ b/addons/shootingrange/functions/fnc_getTargetAnimations.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Returns applicable animations of a target.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_target"];
 

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles hit part event handler.
@@ -24,7 +25,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_target", "_shooter", "", "_impactPosition", "", "_impactSelections", "", "", "", "", "_directHit"];
 

--- a/addons/shootingrange/functions/fnc_isTargetDown.sqf
+++ b/addons/shootingrange/functions/fnc_isTargetDown.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if a target is in "down" animation phase.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_target"];
 

--- a/addons/shootingrange/functions/fnc_moduleInit.sqf
+++ b/addons/shootingrange/functions/fnc_moduleInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Initializes the Shooting Range module.
@@ -12,7 +13,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Exit on Headless Client
 if (!hasInterface && !isDedicated) exitWith {};

--- a/addons/shootingrange/functions/fnc_notifyVicinity.sqf
+++ b/addons/shootingrange/functions/fnc_notifyVicinity.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Shows notifications to everyone in vicinity.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_texts", "_size", ["_includeCaller", false], ["_vicinityRange", NOTIFY_DISTANCE, [0]] ];
 

--- a/addons/shootingrange/functions/fnc_playSoundSignal.sqf
+++ b/addons/shootingrange/functions/fnc_playSoundSignal.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Plays sound signal on all controllers and extra sound sources.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_controller", "_sound", ["_range", NOTIFY_DISTANCE]];
 

--- a/addons/shootingrange/functions/fnc_popupPFH.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFH.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles target pop-ups.
@@ -25,7 +26,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_args", "_idPFH"];
 _args params ["_timeStart", "_duration", "_pauseDuration", "_targetAmount", "_targets", "_targetsInvalid", "_controller", "_controllers", "_name", "_mode", "_triggers"];

--- a/addons/shootingrange/functions/fnc_popupPFHexit.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFHexit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles target pop-ups.
@@ -24,7 +25,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_idPFH", "_controller", "_controllers", "_name", "_targets", "_targetsInvalid", "_mode", "_success", ["_score", 0], ["_maxScore", 0], ["_timeElapsed", 0], ["_triggers", []] ];
 

--- a/addons/shootingrange/functions/fnc_setConfigCountdownTime.sqf
+++ b/addons/shootingrange/functions/fnc_setConfigCountdownTime.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets shooting course pause duration.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controllers", "_countdownTime", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_setConfigDuration.sqf
+++ b/addons/shootingrange/functions/fnc_setConfigDuration.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets shooting course duration.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controllers", "_duration", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_setConfigMode.sqf
+++ b/addons/shootingrange/functions/fnc_setConfigMode.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets shooting course target change event.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controller", "_controllers", "_mode", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_setConfigPauseDuration.sqf
+++ b/addons/shootingrange/functions/fnc_setConfigPauseDuration.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets shooting course pause duration.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controllers", "_pauseDuration", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_setConfigTargetAmount.sqf
+++ b/addons/shootingrange/functions/fnc_setConfigTargetAmount.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sets shooting course duration.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_name", "_controllers", "_targetAmount", "_targets"];
 

--- a/addons/shootingrange/functions/fnc_setTargetGroups.sqf
+++ b/addons/shootingrange/functions/fnc_setTargetGroups.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks current shooting range configuration
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_targets", "_targetsInvalid", "_markers"];
 

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Starts shooting range.
@@ -17,7 +18,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_controller", "_controllers", "_name", "_targets", "_targetsInvalid"];
 

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Stops shooting range.
@@ -21,7 +22,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_controller", "_controllers", "_name", "_targets", "_targetsInvalid", ["_success", false], ["_score", 0], ["_maxScore", 0], ["_timeElapsed", 0]];
 

--- a/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
+++ b/addons/shootingrange/functions/fnc_textsIntoLocalizedString.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Converts array of strings into one partially localized string (localized where string starts with "STR_").
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_texts"];
 TRACE_1("Texts",_texts);

--- a/addons/shootingrange/functions/fnc_triggerPopup.sqf
+++ b/addons/shootingrange/functions/fnc_triggerPopup.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Pops targets on trigger.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_target", "_state"];
 

--- a/addons/zeus/functions/fnc_moduleAddObjectToChronosLocal.sqf
+++ b/addons/zeus/functions/fnc_moduleAddObjectToChronosLocal.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds an object to Chronos persistence (executed locally on client who placed the module).
@@ -12,7 +13,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_logic", "", "_activated"];
 

--- a/addons/zeus/functions/fnc_moduleAddObjectToChronosServer.sqf
+++ b/addons/zeus/functions/fnc_moduleAddObjectToChronosServer.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds an object to Chronos persistence (executed on server through server event).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 

--- a/extras/blank/functions/fnc_empty.sqf
+++ b/extras/blank/functions/fnc_empty.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: [Name of Author(s)]
  * [Description]
@@ -14,6 +15,5 @@
  *
  * Public: [Yes/No]
  */
-#include "script_component.hpp"
 
 diag_log text format["This is here as an example!!!"];


### PR DESCRIPTION
**When merged this pull request will:**
- Do the same as https://github.com/acemod/ACE3/pull/6407 and https://github.com/CBATeam/CBA_A3/pull/937

Regex used:
```bash
find . -name '*.sqf' -type f -exec perl -0777 -pi -e 's/(.+)\#include\s\"script_component\.hpp\"\n/\#include \"script_component\.hpp\"\n\1/gs' -- {} +
```