### PR TITLE
Remove ACRE2 Terrain Loss setting to 0.5 (default since ACRE2 v2.5.0)

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -62,9 +62,6 @@ acex_sitting_enable = true;
 acex_volume_enabled = true;
 acex_volume_lowerInVehicles = true;
 
-// ACRE2
-acre_sys_core_terrainLoss = 0.5;
-
 // ZEN
 zen_editor_disableLiveSearch = true;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title