### PR TITLE
Add NoActions component

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,7 +12,9 @@ Jonpas <jonpas33@gmail.com>
 # CONTRIBUTORS
 Dimaslg
 Omnirock
+R3voA3
 Rory
 System98
 Takelmeifter
 Kresky
+veteran29

--- a/addons/noactions/$PBOPREFIX$
+++ b/addons/noactions/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\noactions

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -1,4 +1,3 @@
-
 #define NO_ACTION_CONIG_ENTRY(NAME, DEFAULT)\
 class NAME: None \
 {\

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -1,8 +1,8 @@
-#define NO_ACTION_CLASS(NAME, DEFAULT)\
-class NAME: None {\
-    show = QUOTE(call compile getText (configFile >> 'CfgActions' >> 'NAME' >> 'GVAR(setting)'));\
-    GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)', DEFAULT)]);\
-}\
+#define NO_ACTION_CLASS(NAME, DEFAULT) \
+class NAME: None { \
+    show = QUOTE(call compile getText (configFile >> 'CfgActions' >> 'NAME' >> 'GVAR(setting)')); \
+    GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)', DEFAULT)]); \
+} \
 
 class CfgActions {
     class None;

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -1,6 +1,5 @@
-#define NO_ACTION_CONIG_ENTRY(NAME, DEFAULT)\
-class NAME: None \
-{\
+#define NO_ACTION_CLASS(NAME, DEFAULT)\
+class NAME: None {\
     show = QUOTE(call compile getText (configFile >> 'CfgActions' >> 'NAME' >> 'GVAR(setting)'));\
     GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)', DEFAULT)]);\
 }\
@@ -8,10 +7,10 @@ class NAME: None \
 class CfgActions {
     class None;
 
-    NO_ACTION_CONIG_ENTRY(Eject, 1);
-    NO_ACTION_CONIG_ENTRY(Rearm, 1);
-    NO_ACTION_CONIG_ENTRY(TurnIn, 1);
-    NO_ACTION_CONIG_ENTRY(TurnOut, 1);
-    NO_ACTION_CONIG_ENTRY(LightOn, 1);
-    NO_ACTION_CONIG_ENTRY(LightOff, 1);
+    NO_ACTION_CLASS(Eject,1);
+    NO_ACTION_CLASS(Rearm,1);
+    NO_ACTION_CLASS(TurnIn,1);
+    NO_ACTION_CLASS(TurnOut,1);
+    NO_ACTION_CLASS(LightOn,1);
+    NO_ACTION_CLASS(LightOff,1);
 };

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -7,7 +7,6 @@ class NAME: None { \
 class CfgActions {
     class None;
 
-    NO_ACTION_CLASS(Eject,1);
     NO_ACTION_CLASS(Rearm,1);
     NO_ACTION_CLASS(TurnIn,1);
     NO_ACTION_CLASS(TurnOut,1);

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -1,0 +1,18 @@
+
+#define NO_ACTION_CONIG_ENTRY(NAME, DEFAULT)\
+class NAME: None \
+{\
+    show = QUOTE(call compile getText (configFile >> 'CfgActions' >> 'NAME' >> 'GVAR(setting)'));\
+    GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)', DEFAULT)]);\
+}\
+
+class CfgActions {
+    class None;
+
+    NO_ACTION_CONIG_ENTRY(Eject, 1);
+    NO_ACTION_CONIG_ENTRY(Rearm, 1);
+    NO_ACTION_CONIG_ENTRY(TurnIn, 1);
+    NO_ACTION_CONIG_ENTRY(TurnOut, 1);
+    NO_ACTION_CONIG_ENTRY(LightOn, 1);
+    NO_ACTION_CONIG_ENTRY(LightOff, 1);
+};

--- a/addons/noactions/CfgEventHandlers.hpp
+++ b/addons/noactions/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/noactions/README.md
+++ b/addons/noactions/README.md
@@ -5,7 +5,6 @@ Allows to declutter scroll menu by disabling actions via CBA settings.
 ### Authors
 
 - [veteran29](https://github.com/veteran29)
-- German translation by [R3vo](https://github.com/R3voA3)
 
 ### Features
 

--- a/addons/noactions/README.md
+++ b/addons/noactions/README.md
@@ -9,10 +9,10 @@ Allows to declutter scroll menu by disabling actions via CBA settings.
 
 ### Features
 
-- Allows to disable following actions:
+- Allows to disable following vanilla action menu actions:
     - Eject
     - Rearm
-    - TurnIn
-    - TurnOut
-    - LightOn
-    - LightOff
+    - Turn In
+    - Turn Out
+    - Light On
+    - Light Off

--- a/addons/noactions/README.md
+++ b/addons/noactions/README.md
@@ -1,0 +1,18 @@
+# About
+
+Allows to declutter scroll menu by disabling actions via CBA settings.
+
+### Authors
+
+- [veteran29](https://github.com/veteran29)
+- German translation by [R3vo](https://github.com/R3voA3)
+
+### Features
+
+- Allows to disable following actions:
+    - Eject
+    - Rearm
+    - TurnIn
+    - TurnOut
+    - LightOn
+    - LightOff

--- a/addons/noactions/XEH_preInit.sqf
+++ b/addons/noactions/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "initSettings.sqf"
+
+ADDON = true;

--- a/addons/noactions/config.cpp
+++ b/addons/noactions/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
+        authors[] = {"veteran29"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgActions.hpp"

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -12,8 +12,6 @@
     true \
 ] call CBA_fnc_addSetting
 
-// Eject
-NO_ACTION_SETTING(Eject,false);
 // Rearm at containers
 NO_ACTION_SETTING(Rearm,false);
 // Vehicle turn in

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -1,0 +1,31 @@
+
+#define NO_ACTION_SETTING(NAME, DEFAULT)\
+[\
+    QGVAR(NAME),\
+    "CHECKBOX",\
+    [\
+        LSTRING(NAME),\
+        LSTRING(NAME)\
+    ],\
+    LSTRING(settings),\
+    DEFAULT,\
+    2,\
+    {\
+        profileNamespace setVariable [QGVAR(NAME), parseNumber !_this];\
+        saveProfileNamespace;\
+    },\
+    true\
+] call CBA_settings_fnc_init
+
+// Eject
+NO_ACTION_SETTING(eject, false);
+// Rearm at containers
+NO_ACTION_SETTING(rearm, false);
+// Vehicle turn in
+NO_ACTION_SETTING(turnin, false);
+// Vehicle turn out
+NO_ACTION_SETTING(turnout, false);
+// Lighs on
+NO_ACTION_SETTING(lighton, false);
+// Lights off
+NO_ACTION_SETTING(lightoff, false);

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -1,15 +1,15 @@
-#define NO_ACTION_SETTING(NAME, DEFAULT) [\
-    QGVAR(NAME),\
-    "CHECKBOX",\
-    [LSTRING(NAME), LSTRING(NAME##_desc)],\
-    ["TAC %1", localize LSTRING(DisplayName)],\
-    DEFAULT,\
-    2,\
-    {\
-        profileNamespace setVariable [QGVAR(NAME), parseNumber !_this];\
-        saveProfileNamespace;\
-    },\
-    true\
+#define NO_ACTION_SETTING(NAME, DEFAULT) [ \
+    QGVAR(NAME), \
+    "CHECKBOX", \
+    [LSTRING(NAME), LSTRING(NAME##_desc)], \
+    ["TAC %1", localize LSTRING(DisplayName)], \
+    DEFAULT, \
+    2, \
+    { \
+        profileNamespace setVariable [QGVAR(NAME), parseNumber !_this]; \
+        saveProfileNamespace; \
+    }, \
+    true \
 ] call CBA_fnc_addSetting
 
 // Eject

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -1,13 +1,8 @@
-
-#define NO_ACTION_SETTING(NAME, DEFAULT)\
-[\
+#define NO_ACTION_SETTING(NAME, DEFAULT) [\
     QGVAR(NAME),\
     "CHECKBOX",\
-    [\
-        LSTRING(NAME),\
-        LSTRING(NAME)\
-    ],\
-    LSTRING(settings),\
+    [LSTRING(NAME), LSTRING(NAME##_desc)],\
+    ["TAC %1", localize LSTRING(DisplayName)],\
     DEFAULT,\
     2,\
     {\
@@ -15,17 +10,17 @@
         saveProfileNamespace;\
     },\
     true\
-] call CBA_settings_fnc_init
+] call CBA_fnc_addSetting
 
 // Eject
-NO_ACTION_SETTING(eject, false);
+NO_ACTION_SETTING(Eject,false);
 // Rearm at containers
-NO_ACTION_SETTING(rearm, false);
+NO_ACTION_SETTING(Rearm,false);
 // Vehicle turn in
-NO_ACTION_SETTING(turnin, false);
+NO_ACTION_SETTING(Turnin,false);
 // Vehicle turn out
-NO_ACTION_SETTING(turnout, false);
+NO_ACTION_SETTING(TurnOut,false);
 // Lighs on
-NO_ACTION_SETTING(lighton, false);
+NO_ACTION_SETTING(LightOn,false);
 // Lights off
-NO_ACTION_SETTING(lightoff, false);
+NO_ACTION_SETTING(LightOff,false);

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(NAME), \
     "CHECKBOX", \
     [LSTRING(NAME), LSTRING(NAME##_desc)], \
-    ["TAC %1", localize LSTRING(DisplayName)], \
+    format ["TAC %1", localize LSTRING(DisplayName)], \
     DEFAULT, \
     2, \
     { \

--- a/addons/noactions/initSettings.sqf
+++ b/addons/noactions/initSettings.sqf
@@ -1,4 +1,5 @@
-#define NO_ACTION_SETTING(NAME, DEFAULT) [ \
+#define NO_ACTION_SETTING(NAME, DEFAULT) \
+[ \
     QGVAR(NAME), \
     "CHECKBOX", \
     [LSTRING(NAME), LSTRING(NAME##_desc)], \

--- a/addons/noactions/script_component.hpp
+++ b/addons/noactions/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT noactions
+#define COMPONENT_BEAUTIFIED No Actions
+#include "\x\tac\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_NOACTIONS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_NOACTIONS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_NOACTIONS
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"

--- a/addons/noactions/stringtable.xml
+++ b/addons/noactions/stringtable.xml
@@ -2,60 +2,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TAC">
     <Package name="No Actions">
-        <Key ID="STR_tac_noactions_settings">
-            <English>TAC NoActions</English>
+        <Key ID="STR_TAC_NoActions_DisplayName">
+            <English>No Actions</English>
         </Key>
         <!-- Eject  -->
-        <Key ID="STR_tac_noactions_eject">
+        <Key ID="STR_TAC_NoActions_Eject">
             <English>Hide Eject action</English>
             <German>Abspringen-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_eject_desc">
+        <Key ID="STR_TAC_NoActions_Eject_Desc">
             <English>Hides the Eject entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Abspringen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>
         <!-- Rearm  -->
-        <Key ID="STR_tac_noactions_rearm">
+        <Key ID="STR_TAC_NoActions_Rearm">
             <English>Hide Rearm action</English>
             <German>Neu bewaffnen-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_rearm_desc">
+        <Key ID="STR_TAC_NoActions_Rearm_Desc">
             <English>Hides the Rearm entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Neu bewaffnen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>
         <!-- Turn In  -->
-        <Key ID="STR_tac_noactions_turnin">
+        <Key ID="STR_TAC_NoActions_TurnIn">
             <English>Hide Turn In action</English>
             <German>Luke schließen-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_turnin_desc">
+        <Key ID="STR_TAC_NoActions_TurnIn_Desc">
             <English>Hides the Turn In entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Luke schließen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>
         <!-- Turn Out  -->
-        <Key ID="STR_tac_noactions_turnout">
+        <Key ID="STR_TAC_NoActions_Turnout">
             <English>Hide Turn Out action</English>
             <German>Luke öffnen-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_turnout_desc">
+        <Key ID="STR_TAC_NoActions_Turnout_Desc">
             <English>Hides the Turn Out entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Luke öffnen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>
         <!-- Lights on  -->
-        <Key ID="STR_tac_noactions_lighton">
+        <Key ID="STR_TAC_NoActions_LightOn">
             <English>Hide Lights on action</English>
             <German>Lichter anschalten-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_lighton_desc">
+        <Key ID="STR_TAC_NoActions_LightOn_Desc">
             <English>Hides the Lights on entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Lichter anschalten-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>
         <!-- Lights off  -->
-        <Key ID="STR_tac_noactions_lightoff">
+        <Key ID="STR_TAC_NoActions_LightOff">
             <English>Hide Lights off action</English>
             <German>Lichter ausschalten-Aktion entfernen</German>
         </Key>
-        <Key ID="STR_tac_noactions_lightoff_desc">
+        <Key ID="STR_TAC_NoActions_LightOff_Desc">
             <English>Hides the Lights off entry from the action menu. Requires a game restart.</English>
             <German>Entfernt die Lichter ausschalten-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
         </Key>

--- a/addons/noactions/stringtable.xml
+++ b/addons/noactions/stringtable.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TAC">
     <Package name="No Actions">

--- a/addons/noactions/stringtable.xml
+++ b/addons/noactions/stringtable.xml
@@ -4,15 +4,6 @@
         <Key ID="STR_TAC_NoActions_DisplayName">
             <English>No Actions</English>
         </Key>
-        <!-- Eject  -->
-        <Key ID="STR_TAC_NoActions_Eject">
-            <English>Hide Eject action</English>
-            <German>Abspringen-Aktion entfernen</German>
-        </Key>
-        <Key ID="STR_TAC_NoActions_Eject_Desc">
-            <English>Hides the Eject entry from the action menu. Requires a game restart.</English>
-            <German>Entfernt die Abspringen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
-        </Key>
         <!-- Rearm  -->
         <Key ID="STR_TAC_NoActions_Rearm">
             <English>Hide Rearm action</English>

--- a/addons/noactions/stringtable.xml
+++ b/addons/noactions/stringtable.xml
@@ -1,0 +1,63 @@
+
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="TAC">
+    <Package name="No Actions">
+        <Key ID="STR_tac_noactions_settings">
+            <English>TAC NoActions</English>
+        </Key>
+        <!-- Eject  -->
+        <Key ID="STR_tac_noactions_eject">
+            <English>Hide Eject action</English>
+            <German>Abspringen-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_eject_desc">
+            <English>Hides the Eject entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Abspringen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+        <!-- Rearm  -->
+        <Key ID="STR_tac_noactions_rearm">
+            <English>Hide Rearm action</English>
+            <German>Neu bewaffnen-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_rearm_desc">
+            <English>Hides the Rearm entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Neu bewaffnen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+        <!-- Turn In  -->
+        <Key ID="STR_tac_noactions_turnin">
+            <English>Hide Turn In action</English>
+            <German>Luke schließen-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_turnin_desc">
+            <English>Hides the Turn In entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Luke schließen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+        <!-- Turn Out  -->
+        <Key ID="STR_tac_noactions_turnout">
+            <English>Hide Turn Out action</English>
+            <German>Luke öffnen-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_turnout_desc">
+            <English>Hides the Turn Out entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Luke öffnen-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+        <!-- Lights on  -->
+        <Key ID="STR_tac_noactions_lighton">
+            <English>Hide Lights on action</English>
+            <German>Lichter anschalten-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_lighton_desc">
+            <English>Hides the Lights on entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Lichter anschalten-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+        <!-- Lights off  -->
+        <Key ID="STR_tac_noactions_lightoff">
+            <English>Hide Lights off action</English>
+            <German>Lichter ausschalten-Aktion entfernen</German>
+        </Key>
+        <Key ID="STR_tac_noactions_lightoff_desc">
+            <English>Hides the Lights off entry from the action menu. Requires a game restart.</English>
+            <German>Entfernt die Lichter ausschalten-Aktion aus dem Aktionsmenü. Benötigt einen Neustart des Spiels.</German>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a component that allows you to remove certain actions from scroll menu to make it less cluttered.

Removable actions (these usually are bound to some keybinds):
 - ~~Eject - Might be useless after next ACE update as commy2 has added same thing. (ACE variant also removes actions added to helos via script)~~
 - Rearm
 - TurnIn
 - TurnOut
 - LightOn
 - LightOff

None of the actions is disabled by default.

Based on:
https://gitlab.com/armaforces/armaforces_no_actions

