### PR TITLE
Default to max item stash quantity in Armory

### DIFF
--- a/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
+++ b/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
@@ -16,15 +16,16 @@
  */
 
 private _quantity = CTRL(NLIST) lnbData [lnbCurSelRow NLIST, 2];
+_quantity = parseNumber _quantity;
 TRACE_1("Amount of selected item",_quantity);
 
 lbClear DROPDOWNAMOUNT;
 
-for "_x" from 1 to (parseNumber _quantity) do {
+for "_x" from 1 to _quantity do {
     lbAdd [DROPDOWNAMOUNT, str _x];
 };
 
-// Set initial value to 1 (will not fire onLBSelChanged)
-lbSetCurSel [DROPDOWNAMOUNT, 0];
+// Set initial value to max/all (will not fire onLBSelChanged)
+lbSetCurSel [DROPDOWNAMOUNT, _quantity];
 
 ctrlShow [DROPDOWNAMOUNT, true];


### PR DESCRIPTION
**When merged this pull request will:**
- Use maximum quantity of the item to be stashed by default, instead of `1`.

Quality of life change for faster stashing.