### PR TITLE
Fix Armory full refresh wiping item list

### DIFF
--- a/addons/armory/XEH_postInitClient.sqf
+++ b/addons/armory/XEH_postInitClient.sqf
@@ -17,8 +17,8 @@ if (!hasInterface) exitWith {};
         CBA_missionTime > (_player getVariable [QGVAR(lastStashTime), 0]) + 1
     }, {
         params ["_player"];
-        // Only update if still open
-        if (!isNull (_player getVariable [QGVAR(object), objNull])) then {
+        // Only update if still open and in "Stash" screen
+        if (!isNull (_player getVariable [QGVAR(object), objNull]) && {GVAR(selectedCategory) == "stash"}) then {
             TRACE_1("Stash force update",_player);
             private _boxContents = call FUNC(getBoxContents);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Stashing something starts the "full refresh" callback and wait. This would interfere with the Armory UI if the user switched to some other (non-stash) part of the Armory fast enough, causing the displayed list to go blank and requiring a re-open.