### PR TITLE
Default to 1 item take quantity in Armory

### DIFF
--- a/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
+++ b/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
@@ -25,7 +25,13 @@ for "_x" from 1 to _quantity do {
     lbAdd [DROPDOWNAMOUNT, str _x];
 };
 
-// Set initial value to max/all (will not fire onLBSelChanged)
-lbSetCurSel [DROPDOWNAMOUNT, [1, _quantity] select (GVAR(selectedCategory) == "stash")];
+// Set initial value to max/all on Stash and 1 on Take (will not fire onLBSelChanged)
+// Using lbAdd string indices (-1)
+if (GVAR(selectedCategory) == "stash") then {
+    lbSetCurSel [DROPDOWNAMOUNT, _quantity - 1];
+} else {
+
+    lbSetCurSel [DROPDOWNAMOUNT, 0];
+};
 
 ctrlShow [DROPDOWNAMOUNT, true];

--- a/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
+++ b/addons/armory/functions/fnc_dialogControl_amountSelection.sqf
@@ -26,6 +26,6 @@ for "_x" from 1 to _quantity do {
 };
 
 // Set initial value to max/all (will not fire onLBSelChanged)
-lbSetCurSel [DROPDOWNAMOUNT, _quantity];
+lbSetCurSel [DROPDOWNAMOUNT, [1, _quantity] select (GVAR(selectedCategory) == "stash")];
 
 ctrlShow [DROPDOWNAMOUNT, true];


### PR DESCRIPTION
**When merged this pull request will:**
- Improve regression from #410
- Retain default 1 when taking items, only set to max when stashing