### PR TITLE
Fatigue - Fix missing file and ignore on HC

### DIFF
--- a/addons/fatigue/CfgEventHandlers.hpp
+++ b/addons/fatigue/CfgEventHandlers.hpp
@@ -1,11 +1,5 @@
-class Extended_PreStart_EventHandlers {
-    class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_preStart));
-    };
-};
-
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_FILE(XEH_postInitClient));
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };

--- a/addons/fatigue/XEH_postInit.sqf
+++ b/addons/fatigue/XEH_postInit.sqf
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {};
+
 // Crouch-Walking made harder
 [QGVAR(kneel), {
     params ["_unit"];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing `XEH_preStart.sqf` file (not needed)
- Not add duty factor on headless clients - Fatigue doesn't run on AI