### PR TITLE
Add Optional CUP ACE3 Hearing Compatibility

### DIFF
--- a/optionals/cup_ace_hearing/$PBOPREFIX$
+++ b/optionals/cup_ace_hearing/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\cup_ace_hearing

--- a/optionals/cup_ace_hearing/CfgWeapons.hpp
+++ b/optionals/cup_ace_hearing/CfgWeapons.hpp
@@ -1,0 +1,80 @@
+#define HEARING(CLASSNAME) \
+    class CLASSNAME: ItemCore { \
+        ace_hearing_protection = 0.75; \
+        ace_hearing_lowerVolume = 0; \
+    }
+
+class CfgWeapons {
+    class ItemCore;
+
+    HEARING(CUP_H_BAF_DDPM_Mk6_CREW_PRR);
+    HEARING(CUP_H_BAF_DPM_Mk6_CREW_PRR);
+    HEARING(CUP_H_BAF_MTP_Mk6_CREW_PRR);
+    HEARING(CUP_H_CZ_Cap_Headphones);
+    HEARING(CUP_H_CZ_Cap_Headphones_des);
+    HEARING(CUP_H_CZ_Helmet05);
+    HEARING(CUP_H_CZ_Helmet07);
+    HEARING(CUP_H_CZ_Helmet08);
+    HEARING(CUP_H_CZ_Helmet09);
+    HEARING(CUP_H_CZ_Helmet10);
+    HEARING(CUP_H_FR_ECH);
+    HEARING(CUP_H_Ger_Beret_TankCommander_Blk);
+    HEARING(CUP_H_Ger_Beret_TankCommander_Grn);
+    HEARING(CUP_H_Ger_Cap_EP_Grn1);
+    HEARING(CUP_H_Ger_Cap_EP_Grn2);
+    HEARING(CUP_H_Ger_Cap_EP_Tan1);
+    HEARING(CUP_H_Ger_Cap_EP_Tan2);
+    HEARING(CUP_H_OpsCore_Black);
+    HEARING(CUP_H_OpsCore_Black_SF);
+    HEARING(CUP_H_OpsCore_Covered_AAF);
+    HEARING(CUP_H_OpsCore_Covered_AAF_SF);
+    HEARING(CUP_H_OpsCore_Covered_Fleck);
+    HEARING(CUP_H_OpsCore_Covered_Fleck_SF);
+    HEARING(CUP_H_OpsCore_Covered_MCAM);
+    HEARING(CUP_H_OpsCore_Covered_MCAM_SF);
+    HEARING(CUP_H_OpsCore_Covered_MCAM_US);
+    HEARING(CUP_H_OpsCore_Covered_MCAM_US_SF);
+    HEARING(CUP_H_OpsCore_Covered_MTP);
+    HEARING(CUP_H_OpsCore_Covered_MTP_SF);
+    HEARING(CUP_H_OpsCore_Covered_Tigerstripe);
+    HEARING(CUP_H_OpsCore_Covered_Tigerstripe_SF);
+    HEARING(CUP_H_OpsCore_Covered_Tropen);
+    HEARING(CUP_H_OpsCore_Covered_Tropen_SF);
+    HEARING(CUP_H_OpsCore_Covered_UCP);
+    HEARING(CUP_H_OpsCore_Covered_UCP_SF);
+    HEARING(CUP_H_OpsCore_Green);
+    HEARING(CUP_H_OpsCore_Green_SF);
+    HEARING(CUP_H_OpsCore_Grey);
+    HEARING(CUP_H_OpsCore_Grey_SF);
+    HEARING(CUP_H_OpsCore_Spray);
+    HEARING(CUP_H_OpsCore_Spray_SF);
+    HEARING(CUP_H_OpsCore_Spray_US);
+    HEARING(CUP_H_OpsCore_Spray_US_SF);
+    HEARING(CUP_H_OpsCore_Tan);
+    HEARING(CUP_H_OpsCore_Tan_SF);
+    HEARING(CUP_H_PMC_Beanie_Headphones_Black);
+    HEARING(CUP_H_PMC_Beanie_Headphones_Khaki);
+    HEARING(CUP_H_PMC_Beanie_Headphones_Winter);
+    HEARING(CUP_H_PMC_Cap_Back_EP_Grey);
+    HEARING(CUP_H_PMC_Cap_Back_EP_Tan);
+    HEARING(CUP_H_PMC_Cap_EP_Grey);
+    HEARING(CUP_H_PMC_Cap_EP_Tan);
+    HEARING(CUP_H_PMC_EP_Headset);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro_DCU);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro_ess);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro_ess_DCU);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro_ess_wdl);
+    HEARING(CUP_H_USArmy_HelmetMICH_earpro_wdl);
+    HEARING(CUP_H_USArmy_Helmet_ECH1_Black);
+    HEARING(CUP_H_USArmy_Helmet_ECH1_Green);
+    HEARING(CUP_H_USArmy_Helmet_ECH1_Sand);
+    HEARING(CUP_H_USArmy_Helmet_ECH2_Black);
+    HEARING(CUP_H_USArmy_Helmet_ECH2_GREEN);
+    HEARING(CUP_H_USArmy_Helmet_ECH2_Sand);
+    HEARING(CUP_H_USMC_Crew_Helmet);
+    HEARING(CUP_H_USMC_MICH2000_DEF_DES);
+    HEARING(CUP_H_USMC_MICH2000_DEF_ESS_DES);
+    HEARING(CUP_H_USMC_MICH2000_DEF_ESS_WDL);
+    HEARING(CUP_H_USMC_MICH2000_DEF_WDL);
+};

--- a/optionals/cup_ace_hearing/README.md
+++ b/optionals/cup_ace_hearing/README.md
@@ -1,0 +1,7 @@
+# About
+
+Adds [ACE3 Hearing](http://ace3mod.com/wiki/feature/hearing.html) support to headgear from [CUP](http://cup-arma3.org/) mod by CUP Team.
+
+### Authors
+
+- [TyroneMF](https://github.com/tyronemf)

--- a/optionals/cup_ace_hearing/config.cpp
+++ b/optionals/cup_ace_hearing/config.cpp
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "tac_main",
+            "ace_hearing",
+            "CUP_Creatures_Extra_OpsCore",
+            "CUP_Creatures_Military_ACR",
+            "CUP_Creatures_Military_BAF",
+            "CUP_Creatures_Military_Germany",
+            "CUP_Creatures_Military_PMC",
+            "CUP_Creatures_Military_USArmy",
+            "CUP_Creatures_Military_USMC",
+        };
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/optionals/cup_ace_hearing/script_component.hpp
+++ b/optionals/cup_ace_hearing/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT cup_ace_hearing
+#define COMPONENT_BEAUTIFIED CUP ACE3 Hearing
+#include "\x\tac\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_CUP_ACE_HEARING
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_CUP_ACE_HEARING
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_CUP_ACE_HEARING
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"


### PR DESCRIPTION
- Add ace hearing compatibility to CUP headgear

(Only items with actual headphones were included.)