### PR TITLE
Fix Apollo name saving

### DIFF
--- a/addons/apollo/XEH_postInitServer.sqf
+++ b/addons/apollo/XEH_postInitServer.sqf
@@ -21,7 +21,7 @@ if (GVAR(enabledPlayers)) then {
     // Save player
     [QGVAR(savePlayer), {
         params ["_player", "_type"];
-        [_player, getPlayerUID _player, _type] call FUNC(playerSingletonSave);
+        [_player, getPlayerUID _player, profileName, _type] call FUNC(playerSingletonSave);
     }] call CBA_fnc_addEventHandler;
 
     // Player died

--- a/addons/apollo/functions/fnc_handleDisconnect.sqf
+++ b/addons/apollo/functions/fnc_handleDisconnect.sqf
@@ -7,17 +7,18 @@
  * 0: Unit <OBJECT>
  * 1: ID <NUMBER> (unused)
  * 2: UID <STRING>
+ * 3: Name <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [unit, 11, "51792927127296126"] call tac_apollo_fnc_handleDisconnect
+ * [unit, 11, "51792927127296126", "Banana"] call tac_apollo_fnc_handleDisconnect
  *
  * Public: No
  */
 
-params ["_unit", "", "_uid"];
+params ["_unit", "", "_uid", "_name"];
 TRACE_1("Handle Disconnect",_this);
 
 // Exit if null unit or saving never started
@@ -26,6 +27,6 @@ if (isNull _unit || {_lastSavedTime == -1}) exitWith {
     ERROR_1("Player not saved on disconnect - UID (%1) or LastSavedTime (%2) undefined!",getPlayerUID _player,_lastSavedTime);
 };
 
-[_unit, _uid, "save"] call FUNC(playerSingletonSave);
+[_unit, _uid, _name, "save"] call FUNC(playerSingletonSave);
 
 deleteVehicle _unit;

--- a/addons/apollo/functions/fnc_playerSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_playerSingletonSave.sqf
@@ -6,21 +6,21 @@
  * Arguments:
  * 0: Player <OBJECT>
  * 1: Player UID <STRING>
- * 2: Type ("save" or "validate") <STRING>
+ * 2: Player Name <STRING>
+ * 3: Type ("save" or "validate") <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, "36182159512951925", "save", "loaded"] call tac_apollo_fnc_playerSingletonSave
+ * [player, "36182159512951925", "Banana", "save"] call tac_apollo_fnc_playerSingletonSave
  *
  * Public: No
  */
 
-params ["_player", "_uid", "_type"];
+params ["_player", "_uid", "_name", "_type"];
 
 // Base
-private _name = name _player;
 private _playerPos = getPosASL _player;
 private _playerDir = getDir _player;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Save name given by `HandleDisconnect` (local `profileName` of leaving player) or `profileName` directly on periodic saves.
- Fix empty or AI names being saved.