### PR TITLE
Fix ACE3 Medical & Balance GRAD Trenches settings

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -65,15 +65,15 @@ acex_volume_enabled = true; // Force client setting
 acex_volume_lowerInVehicles = true; // Force client setting
 
 // GRAD Trenches
-force grad_trenches_functions_allowLongEnvelope = false;
-force grad_trenches_functions_allowSmallEnvelope = false;
-force grad_trenches_functions_allowVehicleEnvelope = false;
-force grad_trenches_functions_allowCamouflage = false;
+grad_trenches_functions_allowLongEnvelope = false;
+grad_trenches_functions_allowSmallEnvelope = false;
+grad_trenches_functions_allowVehicleEnvelope = false;
+grad_trenches_functions_allowCamouflage = false;
 
-force grad_trenches_functions_buildFatigueFactor = 0.2;
-force grad_trenches_functions_shortEnvelopeDigTime = 60;
-force grad_trenches_functions_bigEnvelopeDigTime = 180;
-force grad_trenches_functions_giantEnvelopeDigTime = 300;
+grad_trenches_functions_buildFatigueFactor = 0.2;
+grad_trenches_functions_shortEnvelopeDigTime = 60;
+grad_trenches_functions_bigEnvelopeDigTime = 180;
+grad_trenches_functions_giantEnvelopeDigTime = 300;
 
 // ZEN
 zen_common_disableGearAnim = true;

--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -21,7 +21,7 @@ ace_interaction_disableNegativeRating = true;
 
 ace_map_defaultChannel = 1;
 
-ace_medical_damage_fatalDamageSource = 2; // Either Vital Shots or Sum of Trauma (default: 0 - Vital Shots Only)
+ace_medical_fatalDamageSource = 2; // Either Vital Shots or Sum of Trauma (default: 0 - Vital Shots Only)
 ace_medical_feedback_bloodVolumeEffectType = 0; // Force client setting (default: 0 - Screen Effects)
 ace_medical_spontaneousWakeUpChance = 0.3; // 30% (default: 5%)
 ace_medical_statemachine_fatalInjuriesPlayer = 1; // In Cardiac Arrest (default: 0 - Always)
@@ -63,6 +63,17 @@ acex_sitting_enable = true;
 
 acex_volume_enabled = true; // Force client setting
 acex_volume_lowerInVehicles = true; // Force client setting
+
+// GRAD Trenches
+force grad_trenches_functions_allowLongEnvelope = false;
+force grad_trenches_functions_allowSmallEnvelope = false;
+force grad_trenches_functions_allowVehicleEnvelope = false;
+force grad_trenches_functions_allowCamouflage = false;
+
+force grad_trenches_functions_buildFatigueFactor = 0.2;
+force grad_trenches_functions_shortEnvelopeDigTime = 60;
+force grad_trenches_functions_bigEnvelopeDigTime = 180;
+force grad_trenches_functions_giantEnvelopeDigTime = 300;
 
 // ZEN
 zen_common_disableGearAnim = true;


### PR DESCRIPTION
- Fix Medical damage setting (Sum of Trauma & Large hits to vital organs)
- Remove ability to dig ridiculous trenches.
- Increase time to dig the 3 remaining trenches to 60s, 180s & 300s.
- Reduce stamina factor to match increased times.

Note: These settings are being tested via Mission cba_settings until they're at a balanced place.
