### PR TITLE
Add Optional MELB Tweaks

### DIFF
--- a/optionals/melb_tweaks/$PBOPREFIX$
+++ b/optionals/melb_tweaks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\melb_tweaks

--- a/optionals/melb_tweaks/CfgAmmo.hpp
+++ b/optionals/melb_tweaks/CfgAmmo.hpp
@@ -1,0 +1,25 @@
+class CfgAmmo {
+    class B_762x51_Minigun_Tracer_Red;
+    class B_762x51_Minigun_Tracer_Red_MELB: B_762x51_Minigun_Tracer_Red {
+        // Revert to vanilla
+        tracerScale = 0.6;
+        tracerStartTime = 0.0075;
+        tracerEndTime = 5;
+    };
+
+    class B_762x51_Ball;
+    class B_762x51_Ball_MELB: B_762x51_Ball {
+        // Revert to vanilla
+        tracerScale = 0.6;
+        tracerStartTime = 0.0075;
+        tracerEndTime = 5;
+    };
+
+    class B_127x99_SLAP_Tracer_Red;
+    class B_127x99_SLAP_MELB: B_127x99_SLAP_Tracer_Red {
+        // Revert to vanilla
+        tracerScale = 1.2;
+        tracerStartTime = 0.075;
+        tracerEndTime = 1;
+    };
+};

--- a/optionals/melb_tweaks/CfgMagazines.hpp
+++ b/optionals/melb_tweaks/CfgMagazines.hpp
@@ -1,11 +1,13 @@
 class CfgMagazines {
     class 5000Rnd_762x51_Belt;
     class 6000Rnd_762x51_Belt_Red_MELB: 5000Rnd_762x51_Belt {
+        // Fix "flipping" with AFM - disable recoil
         muzzleImpulseFactor[] = {0, 0}; // default: {0.6, 0.5}
     };
 
     class 500Rnd_127x99_mag_Tracer_Red;
     class 1300Rnd_127x99_mag_Tracer_Red_MELB: 500Rnd_127x99_mag_Tracer_Red {
-        muzzleImpulseFactor[] = {1, 1}; // default: {0.9, 0.4}
+        // Fix "flipping" with AFM - disable recoil
+        muzzleImpulseFactor[] = {0, 0}; // default: {0.9, 0.4}
     };
 };

--- a/optionals/melb_tweaks/CfgMagazines.hpp
+++ b/optionals/melb_tweaks/CfgMagazines.hpp
@@ -1,0 +1,11 @@
+class CfgMagazines {
+    class 5000Rnd_762x51_Belt;
+    class 6000Rnd_762x51_Belt_Red_MELB: 5000Rnd_762x51_Belt {
+        muzzleImpulseFactor[] = {0, 0}; // default: {0.6, 0.5}
+    };
+
+    class 500Rnd_127x99_mag_Tracer_Red;
+    class 1300Rnd_127x99_mag_Tracer_Red_MELB: 500Rnd_127x99_mag_Tracer_Red {
+        muzzleImpulseFactor[] = {1, 1}; // default: {0.9, 0.4}
+    };
+};

--- a/optionals/melb_tweaks/CfgWeapons.hpp
+++ b/optionals/melb_tweaks/CfgWeapons.hpp
@@ -1,0 +1,12 @@
+class CfgWeapons {
+    class M134_minigun;
+    class M134_MELB: M134_minigun {
+        // Revert to vanilla
+        class LowROF: Mode_FullAuto {
+            class StandardSound {
+                begin1[] = {"A3\Sounds_F\arsenal\weapons_vehicles\gatling_762mm\762mm_01_burst", 3.98107 , 1, 1300 , {2, 36879}};
+                soundBegin[] = {"begin1", 1};
+            };
+        };
+    };
+};

--- a/optionals/melb_tweaks/README.md
+++ b/optionals/melb_tweaks/README.md
@@ -1,0 +1,9 @@
+# About
+
+Tweaks helicopters from [[MELB] Mission Enhanced Little Bird](https://forums.bistudio.com/topic/181895-melb-mission-enhanced-little-bird/) mod by Diesel5187 & sykoCrazy.
+
+- Removes `muzzleImpulseFactor` causing desync ("flipping") with AFM.
+
+### Authors
+
+- [Jonpas](http://github.com/jonpas)

--- a/optionals/melb_tweaks/README.md
+++ b/optionals/melb_tweaks/README.md
@@ -2,7 +2,9 @@
 
 Tweaks helicopters from [[MELB] Mission Enhanced Little Bird](https://forums.bistudio.com/topic/181895-melb-mission-enhanced-little-bird/) mod by Diesel5187 & sykoCrazy.
 
-- Removes `muzzleImpulseFactor` causing desync ("flipping") with AFM.
+- Remove gun recoil (`muzzleImpulseFactor`) causing desync/flipping with AFM.
+- Revert M134 and GAU-19 tracers to vanilla.
+- Revert M134 sound to vanilla.
 
 ### Authors
 

--- a/optionals/melb_tweaks/config.cpp
+++ b/optionals/melb_tweaks/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main", "MELB"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Jonpas"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgMagazines.hpp"

--- a/optionals/melb_tweaks/config.cpp
+++ b/optionals/melb_tweaks/config.cpp
@@ -13,4 +13,8 @@ class CfgPatches {
     };
 };
 
+class Mode_FullAuto;
+
+#include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"

--- a/optionals/melb_tweaks/script_component.hpp
+++ b/optionals/melb_tweaks/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT melb_tweaks
+#define COMPONENT_BEAUTIFIED MELB Tweaks
+#include "\x\tac\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_MELB_TWEAKS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_MELB_TWEAKS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MELB_TWEAKS
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Remove gun recoil (`muzzleImpulseFactor`) causing desync/flipping with AFM.
- Revert M134 and GAU-19 tracers to vanilla.
- Revert M134 sound to vanilla.