### PR TITLE
Fix Armory combined CBA Scripted Optic and Accessory variant switch

### DIFF
--- a/addons/armory/dev/test_baseVariants.sqf
+++ b/addons/armory/dev/test_baseVariants.sqf
@@ -1,0 +1,31 @@
+// execVM "x\tac\addons\armory\dev\test_baseVariants.sqf";
+
+#include "\x\tac\addons\armory\script_component.hpp"
+
+private _funcName = QFUNC(getBaseVariant);
+private _result = "";
+
+LOG("Testing " + _funcName);
+TEST_DEFINED(_funcName,"");
+
+if (!isClass (configFile >> "CfgPatches" >> "CUP_Weapons_West_Attachments")) exitWith {
+    LOG("CUP Weapons required for this test!");
+};
+
+_result = ["CUP_Launch_M136"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_Launch_M136",_funcName);
+
+_result = ["CUP_Launch_M136_Loaded"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_Launch_M136",_funcName);
+
+_result = ["CUP_Launch_M136_Used"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_Launch_M136_Used",_funcName);
+
+_result = ["CUP_optic_Elcan_SpecterDR_3D"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_optic_Elcan_SpecterDR",_funcName);
+
+_result = ["CUP_optic_AIMM_M68_BLK_DWN"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_optic_AIMM_M68_BLK",_funcName);
+
+_result = ["CUP_optic_ACOG2_PIP"] call FUNC(getBaseVariant);
+TEST_TRUE(_result == "CUP_optic_ACOG2",_funcName);

--- a/addons/armory/functions/fnc_getBaseVariant.sqf
+++ b/addons/armory/functions/fnc_getBaseVariant.sqf
@@ -22,7 +22,7 @@ private _cfg = configFile >> "CfgWeapons" >> _itemClass;
 // Scripted optic
 private _isScriptedOpticClass = isClass (_cfg >> "CBA_ScriptedOptic");
 private _isScriptedOpticType = (toLower (getText (_cfg >> "weaponInfoType"))) find "cba_scriptedoptic" > -1;
-if (_isScriptedOpticClass || {_isScriptedOpticType}) exitWith {
+if (_isScriptedOpticClass || {_isScriptedOpticType}) then {
     // PIP
     private _baseClasses = configProperties [configFile >> "CBA_PIPItems", "getText _x == _itemClass"];
 
@@ -33,7 +33,7 @@ if (_isScriptedOpticClass || {_isScriptedOpticType}) exitWith {
 
     TRACE_2("Base classes",_itemClass,_baseClasses);
     if !(_baseClasses isEqualTo []) exitWith {
-        configName (_baseClasses select 0)
+        _itemClass = configName (_baseClasses select 0)
     };
     _itemClass
 };
@@ -41,7 +41,7 @@ if (_isScriptedOpticClass || {_isScriptedOpticType}) exitWith {
 // Accessory
 private _hasNextClass = isText (_cfg >> "MRT_SwitchItemNextClass");
 private _hasPrevClass = isText (_cfg >> "MRT_SwitchItemPrevClass");
-if (_hasNextClass || {_hasPrevClass}) exitWith {
+if (_hasNextClass || {_hasPrevClass}) then {
     private _nextClass = _itemClass;
     private _nextCfg = _cfg;
     private _switchEntry = ["MRT_SwitchItemPrevClass", "MRT_SwitchItemNextClass"] select _hasNextClass;
@@ -56,8 +56,8 @@ if (_hasNextClass || {_hasPrevClass}) exitWith {
     };
 
     TRACE_3("Found class",_itemClass,_nextClass,_nextCfg);
-    if (getNumber (_nextCfg >> "scope") == 2) exitWIth {
-        _nextClass
+    if (getNumber (_nextCfg >> "scope") == 2) exitWith {
+        _itemClass = _nextClass
     };
     _itemClass
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Add unit tests for `getBaseVariant` function