### PR TITLE
Apollo - Save vehicle lock state & Customization

### DIFF
--- a/addons/apollo/functions/fnc_vehicleLoad.sqf
+++ b/addons/apollo/functions/fnc_vehicleLoad.sqf
@@ -42,10 +42,16 @@ if (_retrieveVehicles == "ready") then {
     // Allow damage and enable simulation on all vehicles
     {
         _x enableSimulationGlobal true;
-        _x allowDamage true;
 
         // Fix possible issue where physics don't activate until doing it manually (eg. shooting the object)
+        private _vehDamage = getAllHitPointsDamage _x;
         _x setDamage [damage _x, false];
+
+        private _vehicle = _x;
+        _vehDamage params ["_hitPoints", "", "_hitPointsDamage"];
+        {
+            _vehicle setHitPointDamage [_x, _hitPointsDamage select _forEachIndex, false];
+        } forEach _hitPoints;
     } forEach _vehList;
 
     // Set vehicles loaded flag

--- a/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
@@ -56,6 +56,7 @@ switch (true) do {
 
 private _vehicleFuel = fuel _vehicleObject;
 private _vehicleLock = locked _vehicleObject;
+private _vehicleCustomization = [_vehicleObject, ""] call BIS_fnc_exportVehicle;
 
 private _vehicleAmmo = [];
 private _vehicleMagazineCargo = [];
@@ -85,4 +86,4 @@ if (_vehicleAlive) then {
 
 private _vehicleNamePretty = getText (configFile >> "CfgVehicles" >> _vehicleType >> "displayName");
 
-["storeVehicle", _vehicleID, _vehiclePos, _vehicleDir, _vehicleType, _vehicleClass, _vehicleAlive, _vehicleDamage, _hitpoints, _vehicleFuel, _vehicleAmmo, _vehicleMagazineCargo, _vehicleItemCargo, _vehicleWeapons, _vehicleCrew, _vehicleBackPacks, _vehicleBackpackItems, _vehicleBackpackMagazines, _vehicleBackpackWeapons, _driver, _vehicleNamePretty, _vehicleLock] call FUNC(invokeJavaMethod);
+["storeVehicle", _vehicleID, _vehiclePos, _vehicleDir, _vehicleType, _vehicleClass, _vehicleAlive, _vehicleDamage, _hitpoints, _vehicleFuel, _vehicleAmmo, _vehicleMagazineCargo, _vehicleItemCargo, _vehicleWeapons, _vehicleCrew, _vehicleBackPacks, _vehicleBackpackItems, _vehicleBackpackMagazines, _vehicleBackpackWeapons, _driver, _vehicleNamePretty, _vehicleLock, _vehicleCustomization] call FUNC(invokeJavaMethod);

--- a/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
@@ -55,6 +55,7 @@ switch (true) do {
 };
 
 private _vehicleFuel = fuel _vehicleObject;
+private _vehicleLock = locked _vehicleObject;
 
 private _vehicleAmmo = [];
 private _vehicleMagazineCargo = [];
@@ -84,4 +85,4 @@ if (_vehicleAlive) then {
 
 private _vehicleNamePretty = getText (configFile >> "CfgVehicles" >> _vehicleType >> "displayName");
 
-["storeVehicle", _vehicleID, _vehiclePos, _vehicleDir, _vehicleType, _vehicleClass, _vehicleAlive, _vehicleDamage, _hitpoints, _vehicleFuel, _vehicleAmmo, _vehicleMagazineCargo, _vehicleItemCargo, _vehicleWeapons, _vehicleCrew, _vehicleBackPacks, _vehicleBackpackItems, _vehicleBackpackMagazines, _vehicleBackpackWeapons, _driver, _vehicleNamePretty] call FUNC(invokeJavaMethod);
+["storeVehicle", _vehicleID, _vehiclePos, _vehicleDir, _vehicleType, _vehicleClass, _vehicleAlive, _vehicleDamage, _hitpoints, _vehicleFuel, _vehicleAmmo, _vehicleMagazineCargo, _vehicleItemCargo, _vehicleWeapons, _vehicleCrew, _vehicleBackPacks, _vehicleBackpackItems, _vehicleBackpackMagazines, _vehicleBackpackWeapons, _driver, _vehicleNamePretty, _vehicleLock] call FUNC(invokeJavaMethod);


### PR DESCRIPTION
Locking:
Not sure how you set this back, but the `locked` command gives a number, so to re-set it use `lock` instead of `setVehicleLock`

Customization:
Vehicle is exported with `BIS_fnc_exportVehicle` and set again with `BIS_fnc_initVehicle`