### PR TITLE
CBA Settings - Refuel hose length from 12m to 20m

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -45,6 +45,8 @@ ace_overheating_unJamOnreload = true;
 
 ace_rearm_level = 1;
 
+ace_refuel_hoseLength = 20; // Default: 12
+
 ace_repair_addSpareParts = false;
 ace_repair_engineerSetting_fullRepair = 0;
 ace_repair_engineerSetting_Repair = 1;


### PR DESCRIPTION
- title
