### PR TITLE
Add Quick Reference Marker

### DIFF
--- a/addons/ratelmarker/XEH_PREP.hpp
+++ b/addons/ratelmarker/XEH_PREP.hpp
@@ -2,3 +2,5 @@ PREP(canUseMarkerMenu);
 PREP(createMarker);
 PREP(createMarkerMenu);
 PREP(prepareMarker);
+PREP(createQRM);
+PREP(prepareQRM);

--- a/addons/ratelmarker/XEH_postInitClient.sqf
+++ b/addons/ratelmarker/XEH_postInitClient.sqf
@@ -4,12 +4,19 @@
 if (!hasInterface) exitWith {};
 
 // Add Keybind
-["TAC", QGVAR(OpenRatelMarker), localize LSTRING(Open), {
+["TAC", QGVAR(OpenRatelMarker), LLSTRING(Open), {
     if ([vehicle ACE_player] call FUNC(canUseMarkerMenu)) then {
         call FUNC(createMarkerMenu);
     };
     false
 }, {false}, [19, [true, true, true]], false] call CBA_fnc_addKeybind; // Ctrl+Alt+Shift+R
+
+["TAC", QGVAR(CreateQRM), LLSTRING(QRM_Create), {
+    if ([vehicle ace_player] call FUNC(canUseMarkerMenu)) then {
+        call FUNC(prepareQRM);
+    };
+    false
+}, "", [20, [true, true, true]], false] call CBA_fnc_addKeybind; // Ctrl+Alt+Shift+R
 
 // Client EH
 [QGVAR(created), FUNC(createMarker)] call CBA_fnc_addEventHandler;

--- a/addons/ratelmarker/XEH_postInitClient.sqf
+++ b/addons/ratelmarker/XEH_postInitClient.sqf
@@ -16,7 +16,7 @@ if (!hasInterface) exitWith {};
         call FUNC(prepareQRM);
     };
     false
-}, "", [20, [true, true, true]], false] call CBA_fnc_addKeybind; // Ctrl+Alt+Shift+R
+}, ""] call CBA_fnc_addKeybind;
 
 // Client EH
 [QGVAR(created), FUNC(createMarker)] call CBA_fnc_addEventHandler;

--- a/addons/ratelmarker/XEH_preInit.sqf
+++ b/addons/ratelmarker/XEH_preInit.sqf
@@ -7,3 +7,11 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 ADDON = true;
+
+[
+    QGVAR(QuickReferenceMarkerMode),
+    "LIST",
+    LSTRING(QRM_Mode),
+    LSTRING(QRM_settingsCategory),
+    [[0, 1, 2], [LSTRING(QRM_Disabled), LSTRING(QRM_VehiclePos), LSTRING(QRM_ViewPos)], 2]
+] call CBA_fnc_addSetting;

--- a/addons/ratelmarker/XEH_preInit.sqf
+++ b/addons/ratelmarker/XEH_preInit.sqf
@@ -12,6 +12,6 @@ ADDON = true;
     QGVAR(QuickReferenceMarkerMode),
     "LIST",
     LSTRING(QRM_Mode),
-    LSTRING(QRM_settingsCategory),
-    [[0, 1, 2], [LSTRING(QRM_Disabled), LSTRING(QRM_VehiclePos), LSTRING(QRM_ViewPos)], 2]
+    format ["TAC %1", localize "str_a3_rscdisplaywelcome_expa_parc_list6_title"],
+    [[0, 1, 2], [ACELSTRING(Common,Disabled), LSTRING(QRM_VehiclePos), LSTRING(QRM_ViewPos)], 2]
 ] call CBA_fnc_addSetting;

--- a/addons/ratelmarker/functions/fnc_createQRM.sqf
+++ b/addons/ratelmarker/functions/fnc_createQRM.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: JoramD
+ * Create Quick Reference Marker.
+ *
+ * Arguments:
+ * 0: Marker Position <PositionASL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_markerPos] call tac_ratelmarker_fnc_createQRM;
+ *
+ * Public: No
+ */
+
+params ["_markerPos"];
+
+[
+    format ["QRM [%1] (%2)", (mapGridPosition _markerPos), [daytime, "HH:MM"] call BIS_fnc_timeToString],
+    _markerPos
+] call ace_microdagr_fnc_deviceAddWaypoint;

--- a/addons/ratelmarker/functions/fnc_createQRM.sqf
+++ b/addons/ratelmarker/functions/fnc_createQRM.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * [_markerPos] call tac_ratelmarker_fnc_createQRM;
+ * [_markerPos] call tac_ratelmarker_fnc_createQRM
  *
  * Public: No
  */
@@ -18,6 +18,6 @@
 params ["_markerPos"];
 
 [
-    format ["QRM [%1] (%2)", (mapGridPosition _markerPos), [daytime, "HH:MM"] call BIS_fnc_timeToString],
+    format ["QRM [%1] (%2)", mapGridPosition _markerPos, [daytime, "HH:MM"] call BIS_fnc_timeToString],
     _markerPos
-] call ace_microdagr_fnc_deviceAddWaypoint;
+] call ACEFUNC(microdagr,deviceAddWaypoint);

--- a/addons/ratelmarker/functions/fnc_prepareQRM.sqf
+++ b/addons/ratelmarker/functions/fnc_prepareQRM.sqf
@@ -7,10 +7,10 @@
  * None
  *
  * Return Value:
- * Can Use RATEL Marker menu <BOOL>
+ * None
  *
  * Example:
- * [vehicle, player] call tac_ratelmarker_fnc_canUseMarkerMenu;
+ * call tac_ratelmarker_fnc_prepareQRM
  *
  * Public: No
  */
@@ -31,9 +31,9 @@ if (GVAR(QuickReferenceMarkerMode) == 2) then {
 
     private _markerPos = terrainIntersectAtASL [_traceBegin, _traceEnd];
 
-    if !(_markerPos isEqualTo [0,0,0]) then {
+    if !(_markerPos isEqualTo [0, 0, 0]) then {
         [_markerPos] call FUNC(createQRM);
     } else {
-        "Could not create Quick Reference Marker" call CBA_fnc_notify;
+        LLSTRING(QRM_Create) call CBA_fnc_notify;
     };
 };

--- a/addons/ratelmarker/functions/fnc_prepareQRM.sqf
+++ b/addons/ratelmarker/functions/fnc_prepareQRM.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/*
+ * Author: JoramD
+ * Prepare Quick Reference Marker.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Can Use RATEL Marker menu <BOOL>
+ *
+ * Example:
+ * [vehicle, player] call tac_ratelmarker_fnc_canUseMarkerMenu;
+ *
+ * Public: No
+ */
+
+if (GVAR(QuickReferenceMarkerMode) == 0) exitwith {};
+
+private _playerVehicle = vehicle ace_player;
+private _vehicleRole = assignedVehicleRole ace_player;
+
+if (GVAR(QuickReferenceMarkerMode) == 1) then {
+    private _markerPos = getPosASL _playerVehicle;
+    [_markerPos] call FUNC(createQRM);
+};
+
+if (GVAR(QuickReferenceMarkerMode) == 2) then {
+    private _traceBegin = AGLToASL positionCameraToWorld [0, 0, 0];
+    private _traceEnd = AGLToASL positionCameraToWorld [0, 0, 5000];
+
+    private _markerPos = terrainIntersectAtASL [_traceBegin, _traceEnd];
+
+    if !(_markerPos isEqualTo [0,0,0]) then {
+        [_markerPos] call FUNC(createQRM);
+    } else {
+        "Could not create Quick Reference Marker" call CBA_fnc_notify;
+    };
+};

--- a/addons/ratelmarker/stringtable.xml
+++ b/addons/ratelmarker/stringtable.xml
@@ -25,12 +25,6 @@
             <German>RATEL Markierung erstellt (Karte öffnen um zu zentrieren)</German>
             <French>Balise RATEL crée (Ouvrir la carte pour focaliser)</French>
         </Key>
-        <Key ID="STR_TAC_RatelMarker_QRM_settingsCategory">
-            <English>TAC Quick Reference Marker</English>
-        </Key>
-        <Key ID="STR_TAC_RatelMarker_QRM_Disabled">
-            <English>Disabled</English>
-        </Key>
         <Key ID="STR_TAC_RatelMarker_QRM_Create">
             <English>Create Quick Reference Marker</English>
         </Key>
@@ -41,6 +35,9 @@
             <English>Vehicle Position</English>
         </Key>
         <Key ID="STR_TAC_RatelMarker_QRM_ViewPos">
+            <English>View Position</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_Error">
             <English>View Position</English>
         </Key>
     </Package>

--- a/addons/ratelmarker/stringtable.xml
+++ b/addons/ratelmarker/stringtable.xml
@@ -38,7 +38,7 @@
             <English>View Position</English>
         </Key>
         <Key ID="STR_TAC_RatelMarker_QRM_Error">
-            <English>View Position</English>
+            <English>Could not create Quick Reference Marker</English>
         </Key>
     </Package>
 </Project>

--- a/addons/ratelmarker/stringtable.xml
+++ b/addons/ratelmarker/stringtable.xml
@@ -25,5 +25,23 @@
             <German>RATEL Markierung erstellt (Karte öffnen um zu zentrieren)</German>
             <French>Balise RATEL crée (Ouvrir la carte pour focaliser)</French>
         </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_settingsCategory">
+            <English>TAC Quick Reference Marker</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_Disabled">
+            <English>Disabled</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_Create">
+            <English>Create Quick Reference Marker</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_Mode">
+            <English>Quick Reference Marker Mode</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_VehiclePos">
+            <English>Vehicle Position</English>
+        </Key>
+        <Key ID="STR_TAC_RatelMarker_QRM_ViewPos">
+            <English>View Position</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add Quick Reference Marker keybind/functionality

Quick Reference Markers (QRMs) allow pilots to quickly make a marker on their MicroDAGR of a point of interest.
