### PR TITLE
Servers - Fix AoW Showcase not being deleted

### DIFF
--- a/addons/servers/CfgMainMenuSpotlight.hpp
+++ b/addons/servers/CfgMainMenuSpotlight.hpp
@@ -39,6 +39,6 @@ class CfgMainMenuSpotlight {
 
     delete SP_FD14;
 
-    delete AoW_Showcase_Future;
     delete AoW_Showcase_AoW;
+    delete AoW_Showcase_Future;
 };


### PR DESCRIPTION
RPT: 12:15:54 Cannot delete class AoW_Showcase_Future, it is referenced somewhere (used as a base class probably).

`AoW_Showcase_AoW` inherits from `AoW_Showcase_Future` so it can't be deleted first.