### PR TITLE
Settings - Disable weapon cookoff

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -12,8 +12,6 @@ ace_common_checkPBOsAction = 2;
 ace_common_checkPBOsCheckAll = true;
 ace_common_checkPBOsWhitelist = "['ace_noactionmenu', 'Blastcore_MainCore', 'Blastcore_VEP', 'WarFXPE']";
 
-ace_overheating_cookoffCoef = 0; // Disabled (default: 1)
-
 ace_dragging_dragAndFire = true;
 
 ace_finger_enabled = true;
@@ -46,6 +44,7 @@ ace_nightvision_aimDownSightsBlur = 0.4;
 ace_nightvision_effectScaling = 0.5;
 ace_nightvision_noiseScaling = 0.3;
 
+ace_overheating_cookoffCoef = 0; // Disabled (default: 1)
 ace_overheating_unJamOnreload = true;
 
 ace_rearm_level = 1;

--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -12,6 +12,8 @@ ace_common_checkPBOsAction = 2;
 ace_common_checkPBOsCheckAll = true;
 ace_common_checkPBOsWhitelist = "['ace_noactionmenu', 'Blastcore_MainCore', 'Blastcore_VEP', 'WarFXPE']";
 
+ace_overheating_cookoffCoef = 0; // Disabled (default: 1)
+
 ace_dragging_dragAndFire = true;
 
 ace_finger_enabled = true;


### PR DESCRIPTION
- Can't see any practical use for it other than being a major annoyance.