### PR TITLE
Apollo - Don't log position and loadout on validation

### DIFF
--- a/addons/apollo/functions/fnc_playerSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_playerSingletonSave.sqf
@@ -52,7 +52,7 @@ TRACE_2("Singleton Save",_type,_serverReply);
 if (_type == "validate" && {_serverReply == "success"}) exitWith {
     // No simulation toggling due to possible lag breaking correct position and direction setting
     ["infantryLoaded", _uid] call FUNC(invokeJavaMethod);
-    INFO_4("Player '%1' (%2) validated successfully (Position: %3 - Loadout: %4)",_name,_uid,_playerPos,_loadout);
+    INFO_2("Player '%1' (%2) validated successfully",_name,_uid);
 };
 
 if (_serverReply == "terminated") then {


### PR DESCRIPTION
**When merged this pull request will:**
- Don't log position and loadout on validation as it is not correct on the client at this time