### PR TITLE
Armory - Fix quantity type for use of `parseSimpleArray`

### DIFF
--- a/addons/apollo/functions/fnc_playerLoadClient.sqf
+++ b/addons/apollo/functions/fnc_playerLoadClient.sqf
@@ -56,7 +56,11 @@ if (_returnCode == 0 && {_errorCode == 0} && {_result != "error"}) then {
     };
 
     // Validate
-    [QGVAR(savePlayer), [_player, profileName, "validate"]] call CBA_fnc_serverEvent;
+    // Delay to allow Arma server to get the new loadout before attempting to validate
+    // Validation does nothing at this moment as it was never properly implemented in the backend
+    [{
+        [QGVAR(savePlayer), [_this, profileName, "validate"]] call CBA_fnc_serverEvent;
+    }, _player, 1] call CBA_fnc_waitAndExecute;
 
     // Has to be executed where unit is local
     _player allowDamage true;

--- a/addons/armory/functions/fnc_dialogControl_populateList.sqf
+++ b/addons/armory/functions/fnc_dialogControl_populateList.sqf
@@ -36,7 +36,7 @@ _armoryData sort true; // Errors when used in combination with forEach
     _x params ["_className", "_subCategory", "", "_quantity"];
 
     // Skip listing this item if there are none of them
-    if (parseNumber _quantity > 0) then {
+    if (_quantity > 0) then {
         // Get correct config
         private _configCfg = configName (configHierarchy (_className call CBA_fnc_getItemConfig) param [1, configNull]);
         if (_configCfg == "") then {
@@ -59,13 +59,13 @@ _armoryData sort true; // Errors when used in combination with forEach
                 _displayName = [_displayName, "..."] joinString "";
             };
 
-            private _quantityList = [_quantity, "∞"] select (_configCfg == "CfgUnitInsignia");
+            private _quantityList = [str _quantity, "∞"] select (_configCfg == "CfgUnitInsignia");
             lnbAddRow [NLIST, ["", _displayName, _quantityList]];
             lbSetTooltip [NLIST, _rowNum * 3, _tooltip]; // Requires multiplication by 3 to be set on proper index (no idea why)
 
             // Set hidden data with classname to displayName column and quantity to quantity column
             lnbSetData [NLIST, [_rowNum, 1], _className];
-            lnbSetData [NLIST, [_rowNum, 2], _quantity];
+            lnbSetData [NLIST, [_rowNum, 2], str _quantity];
 
             // Set picture
             private _pictureType = ["picture", "texture"] select (_configCfg == "CfgUnitInsignia");

--- a/addons/armory/functions/fnc_getBoxContents.sqf
+++ b/addons/armory/functions/fnc_getBoxContents.sqf
@@ -27,25 +27,25 @@ private _backpackCargo = getBackpackCargo _object;
 _itemCargo params ["_itemClassNames", "_itemQuantity"];
 {
     private _quantity = str (_itemQuantity select _forEachIndex);
-    _contents pushBack [_x, "Items", "", _quantity];
+    _contents pushBack [_x, "Items", "", parseNumber _quantity];
 } forEach _itemClassNames;
 
 _weaponCargo params ["_weaponClassNames", "_weaponQuantity"];
 {
     private _quantity = str (_weaponQuantity select _forEachIndex);
-    _contents pushBack [_x, "Weapons", "", _quantity];
+    _contents pushBack [_x, "Weapons", "", parseNumber _quantity];
 } forEach _weaponClassNames;
 
 _magazineCargo params ["_magazineClassNames", "_magazineQuantity"];
 {
     private _quantity = str (_magazineQuantity select _forEachIndex);
-    _contents pushBack [_x, "Ammo", "", _quantity];
+    _contents pushBack [_x, "Ammo", "", parseNumber _quantity];
 } forEach _magazineClassNames;
 
 _backpackCargo params ["_backpackClassNames", "_backpackQuantity"];
 {
     private _quantity = str (_backpackQuantity select _forEachIndex);
-    _contents pushBack [_x, "Backpacks", "", _quantity];
+    _contents pushBack [_x, "Backpacks", "", parseNumber _quantity];
 } forEach _backpackClassNames;
 
 _contents

--- a/addons/armory/functions/fnc_subtractData.sqf
+++ b/addons/armory/functions/fnc_subtractData.sqf
@@ -22,7 +22,7 @@ private _armoryDataSubtracted = [];
     _x params ["_className", "_subCategory", "_description", "_quantity"];
 
     if (_selectedItem == _className) then {
-        _quantity = (parseNumber _quantity) - (parseNumber _selectedAmount);
+        _quantity = _quantity - (parseNumber _selectedAmount);
         if (_quantity > 0) then {
             _armoryDataSubtracted pushBack [_className, _subCategory, _description, str _quantity];
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Armory - Fix quantity type for use of `parseSimpleArray`
- Apollo - Delay validation to allow server to sync loadout