### PR TITLE
Extensions - Handle non-ASCII characters gracefully

### DIFF
--- a/extensions/apollo-client/src/lib.rs
+++ b/extensions/apollo-client/src/lib.rs
@@ -24,9 +24,12 @@ macro_rules! url {
 
 fn request(api: String) -> String {
     info!("Request: {}", api);
-    let response = reqwest::blocking::get(&api).unwrap().text().unwrap();
-    info!("Response ({} bytes): {}", response.len(), response);
+    let mut response = reqwest::blocking::get(&api).unwrap().text().unwrap();
 
+    // Replace non-ASCII characters with a warning
+    response = response.replace(|c: char| !c.is_ascii(), "[INVALID-CHAR]");
+
+    info!("Response ({} bytes): {}", response.len(), response);
     if response.len() <= EXT_RET_BYTES {
         info!("Direct response");
         response

--- a/extensions/apollo-client/src/main.rs
+++ b/extensions/apollo-client/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
 
     //get_training_identifiers(String::from("76561198048995566"));
     //load_player(String::from("76561198048995566"), true);
-
     //load_armory(String::from("item"), String::from("76561198048995566"), false);
-    get_accessible_item_classes(String::from("76561198048995566"));
+    load_armory(String::from("rifle"), String::from("76561198024182729"), false);
+    //get_accessible_item_classes(String::from("76561198048995566"));
 
     if get() != "error" {
         while get() != "done" {}


### PR DESCRIPTION
**When merged this pull request will:**
- Fix crash found by @Lairdd1989 with Armory item descriptions containing non-ASCII whitespaces.
- Replace non-ASCII characters with `[INVALID-CHAR]` so it can be fixed in Armory itself as well.