### PR TITLE
Change define CHANCE_HEADGEAR

### DIFF
--- a/addons/insurgents/script_component.hpp
+++ b/addons/insurgents/script_component.hpp
@@ -23,7 +23,7 @@
 #define GEAR_SETTING(var) (format [QGVAR(enabled_%1), var])
 #define GEAR_ENABLED(var) (missionNamespace getVariable [GEAR_SETTING(var), true])
 
-#define CHANCE_HEADGEAR 0.5
+#define CHANCE_HEADGEAR 0.95
 #define CHANCE_FACEWEAR 0.3
 #define CHANCE_PISTOL 0.3
 #define CHANCE_LAUNCHER 0.1


### PR DESCRIPTION
Change Value from 0.5 ->0.95
This changes chance of the insurgent units not having headgear from 50/50 to 1 in 20.

Having values as configurable would probs be a better solution
