### PR TITLE
Apollo - Add ThingX (PhysX objects) to vehicle classes

### DIFF
--- a/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_vehicleSingletonSave.sqf
@@ -44,13 +44,14 @@ if (_vehicleObject isKindOf "AllVehicles") then {
     } forEach (crew _vehicleObject);
 };
 
-private _vehicleClass = "";
-switch (true) do {
+// Unknown class does not get height added on spawn, all other defined classes do
+private _vehicleClass = switch (true) do {
     case (_vehicleObject isKindOf "Car"): {_vehicleClass = "Car"};
     case (_vehicleObject isKindOf "Plane"): {_vehicleClass = "Plane"};
     case (_vehicleObject isKindOf "Helicopter"): {_vehicleClass = "Helicopter"};
     case (_vehicleObject isKindOf "Tank"): {_vehicleClass = "Tank"};
     case (_vehicleObject isKindOf "Ship"): {_vehicleClass = "Ship"};
+    case (_vehicleObject isKindOf "ThingX"): {_vehicleClass = "ObjectPhysX"};
     default {_vehicleClass = "Unknown"};
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Together with Apollo change (already deployed) only add additional height on spawn if one of the classes, while `Unknown` will be spawned as-is.

This is first change towards better Apollo support for Trenches. However, due to how they work, additional work has to be done (as part of this or separate PRs):
- Spawn trench a bit lower (it's 0.36 too high for some reason) - trenches code probably sets position after spawning? #201 
- Save and set animation state OR we just accept they will all be fully build after server restart #201 