### PR TITLE
Difficulties - Set AI skill to 1.0 and allow maximum Spot Distance and Time in Theseus difficulty

### DIFF
--- a/addons/difficulties/CfgAILevelPresets.hpp
+++ b/addons/difficulties/CfgAILevelPresets.hpp
@@ -3,6 +3,6 @@ class CfgAILevelPresets {
     class GVAR(Theseus): Custom {
         displayName = "Theseus";
         precisionAI = 0.4;
-        skillAI = 0.8;
+        skillAI = 1.0;
     };
 };

--- a/addons/difficulties/CfgAISkill.hpp
+++ b/addons/difficulties/CfgAISkill.hpp
@@ -16,6 +16,6 @@ class CfgAISkill {
     endurance[] = {0, 0, 1, 0.7};
     general[] = {0, 0, 1, 0.9};
     //reloadSpeed[] changes break rapid firing in single fire mode for players
-    spotDistance[] = {0, 0, 1, 0.9};
-    spotTime[] = {0, 0, 1, 0.7};
+    spotDistance[] = {0, 0, 1, 1};
+    spotTime[] = {0, 0, 1, 1};
 };

--- a/addons/difficulties/CfgDifficultyPresets.hpp
+++ b/addons/difficulties/CfgDifficultyPresets.hpp
@@ -28,11 +28,4 @@ class CfgDifficultyPresets {
             weaponInfo = 1;
         };
     };
-
-    class GVAR(TheseusSOG): GVAR(Theseus) {
-        displayName = "Theseus SOG";
-        description = "Custom difficulty for Theseus SOG gameplay.";
-        optionDescription = "Custom difficulty for Theseus SOG gameplay.";
-        levelAI = "sog"; // precision = 0.3, skill = 1
-    };
 };

--- a/addons/difficulties/CfgDifficultyPresets.hpp
+++ b/addons/difficulties/CfgDifficultyPresets.hpp
@@ -11,7 +11,7 @@ class CfgDifficultyPresets {
             commands = 0;
             deathMessages = 0;
             detectedMines = 0;
-            enemyTags= 0;
+            enemyTags = 0;
             friendlyTags = 0;
             groupIndicators = 0;
             mapContent = 0;

--- a/addons/difficulties/CfgDifficultyPresets.hpp
+++ b/addons/difficulties/CfgDifficultyPresets.hpp
@@ -28,4 +28,11 @@ class CfgDifficultyPresets {
             weaponInfo = 1;
         };
     };
+
+    class GVAR(TheseusSOG): GVAR(Theseus) {
+        displayName = "Theseus SOG";
+        description = "Custom difficulty for Theseus SOG gameplay.";
+        optionDescription = "Custom difficulty for Theseus SOG gameplay.";
+        levelAI = "sog"; // precision = 0.3, skill = 1
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- ~~Add Theseus SOG difficulty~~
  - ~~SOG AI level (precision = 0.3, skill = 1)~~
  - ~~Same Options regarding HUD, markers, killed messages etc.~~
- Set `skillAI` to `1` in Theseus difficulty.
  - Adapts SOG's `skillAI` setting, now usable for both without separate difficulties (see below 2 comments).
- Increase maximum Spot Distance and Spot Time to `1`