### PR TITLE
Server - Remove Western Sahara spotlights

### DIFF
--- a/addons/servers/CfgMainMenuSpotlight.hpp
+++ b/addons/servers/CfgMainMenuSpotlight.hpp
@@ -41,4 +41,9 @@ class CfgMainMenuSpotlight {
 
     delete AoW_Showcase_AoW;
     delete AoW_Showcase_Future;
+
+    // Western Sahara
+    delete Extraction_lxWS;
+    delete Showcase_Alchemist_lxWS;
+    delete Showcase_VR_lxWS;
 };


### PR DESCRIPTION
- Deletes the 3 spotlights that are currently there, tested without running WS and it fails silently, nothing in RPT.
