### PR TITLE
Settings - Change Allow Repair to Anyone

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -57,10 +57,10 @@ ace_rearm_level = 1;
 
 ace_refuel_hoseLength = 30; // Default: 12
 
-ace_repair_addSpareParts = false;
-ace_repair_engineerSetting_fullRepair = 0;
-ace_repair_engineerSetting_Repair = 1;
-ace_repair_fullRepairLocation = 3;
+ace_repair_addSpareParts = false; // No (default: true - Yes)
+ace_repair_engineerSetting_fullRepair = 0; // Anyone (default: 2 - Advanced Engineer only)
+ace_repair_engineerSetting_Repair = 0; // Anyone (default: 1 - Engineer only)
+ace_repair_fullRepairLocation = 3; // Repair Facility or Vehicle (default: 2 - Repair Facility only)
 
 ace_respawn_removeDeadBodiesDisconnected = false;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Change Allow Repair to Anyone.

Preparation for changes to Engineer role:
> - Basic repair: can repair a vehicle up to 40% with a toolkit (included in basic training).
> - Engineer repair: can repair a vehicle up to 60% with a toolkit in the field (engineer trained).
> - Full repair: with the proper facilities (base or repair vehicle) anyone with a toolkit can fix a vehicle fully.
>
> Toolkit as company-provided asset.