### PR TITLE
Mission - Optimize Hunt target selection

### DIFF
--- a/addons/mission/functions/fnc_hunt.sqf
+++ b/addons/mission/functions/fnc_hunt.sqf
@@ -48,11 +48,13 @@ _hunters setCombatMode "RED";
     // Select closest player group
     if (isNull _hunted) then {
         private _hunterLeader = leader _hunters;
-        private _nearest = nearestObjects [_hunterLeader, ["CAManBase"], _searchDistance, true];
-        _nearest = _nearest select {isPlayer _x};
-        _nearest = _nearest param [0, objNull];
-        _hunted = group _nearest;
-        _args set [2, _hunted];
+        private _players = (call CBA_fnc_players) select {isTouchingGround _x};
+        private _playerWithinDistance = _players findIf {(_hunterLeader distance _x) < _searchDistance};
+
+        if (_playerWithinDistance != -1) then {
+            private _hunted = group (_players select _playerWithinDistance);
+            _args set [2, _hunted];
+        };
     } else {
         // Get hunted Leader
         private _huntedLeader = leader _hunted;

--- a/addons/mission/functions/fnc_hunt.sqf
+++ b/addons/mission/functions/fnc_hunt.sqf
@@ -48,11 +48,12 @@ _hunters setCombatMode "RED";
     // Select closest player group
     if (isNull _hunted) then {
         private _hunterLeader = leader _hunters;
-        private _players = (call CBA_fnc_players) select {isTouchingGround _x};
-        private _playerWithinDistance = _players findIf {(_hunterLeader distance _x) < _searchDistance};
+        private _players = (call CBA_fnc_players) select {
+            isTouchingGround _x && {(_hunterLeader distance _x) < _searchDistance}
+        };
 
-        if (_playerWithinDistance != -1) then {
-            private _hunted = group (_players select _playerWithinDistance);
+        if (_players isNotEqualTo []) then {
+            private _hunted = group (selectRandom _players);
             _args set [2, _hunted];
         };
     } else {

--- a/addons/mission/functions/fnc_reinforcements.sqf
+++ b/addons/mission/functions/fnc_reinforcements.sqf
@@ -46,7 +46,7 @@ if (_anyClose isEqualTo [] || CBA_MissionTime == 0) then {
         [{
             params ["_group", "_searchDistance"];
             [_group, nil, nil, _searchDistance] call FUNC(hunt);
-        }, [_group, _searchDistance], 10] call CBA_fnc_waitAndExecute;
+        }, [_group, _searchDistance], (random 1) + 10] call CBA_fnc_waitAndExecute;
     };
 } else {
     if (is3DENPreview) then {


### PR DESCRIPTION
Noticed some major FPS drops with only the hunt function being ran, deleted groups that were hunting and FPS stabilised.

Data from Alans mission where I noticed the issue ( I skipped 2 hours in-game to get a bunch of groups hunting and have something identical to compare to)

Units active - 67 (approx 50 on hunt)
Hunt was being called from Reinforcements (reinforcements added to mission so it called new hunt)

Original:
Server FPS every check time: 3-14.
Server FPS normal: 90-100.

Rewrite:
Server FPS every check time: 70-77.
Server FPS normal: 90-100.

This actually made a huge difference.

Local benchmarking, (VR mission with player & one group for check):
Original:
- 0.0682 ms
- 0.071 ms
- 0.0704 ms
- 0.072 ms
- 0.071 ms

Rewrite:
- 0.0136 ms
- 0.015 ms
- 0.0138 ms
- 0.0156 ms
- 0.0148 ms