### PR TITLE
Mission - Fix players included in Monitor Units AI counting

### DIFF
--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -21,9 +21,15 @@ params [["_type", 0]];
 
 switch (_type) do {
     case 0: {
-        format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", west countSide allUnits, east countSide allUnits, resistance countside allUnits, civilian countSide allUnits, count playableUnits]
+        private _west = west countSide allUnits - playableUnits;
+        private _east = east countSide allUnits - playableUnits;
+        private _resistance = resistance countSide allUnits - playableUnits;
+        private _civilian = civilian countside allUnits - playableUnits;
+        format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", _west, _east, _resistance , _civilian, count playableUnits]
     };
     case 1: {
-        format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", count (allUnits - playableUnits select {simulationEnabled _x}), count (allUnits select {!simulationEnabled _x}), count agents, diag_fps]
+        private _active = count (allUnits - playableUnits select {simulationEnabled _x});
+        private _inactive = count (allUnits select {!simulationEnabled _x});
+        format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", _active, _inactive, count agents, diag_fps]
     };
 };

--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -29,7 +29,7 @@ switch (_type) do {
     };
     case 1: {
         private _active = count (allUnits select {simulationEnabled _x}) - count playableUnits;
-        private _inactive = count allUnits select {!simulationEnabled _x});
+        private _inactive = count (allUnits select {!simulationEnabled _x});
         format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", _active, _inactive, count agents, diag_fps]
     };
 };

--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -24,6 +24,6 @@ switch (_type) do {
         format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", west countSide allUnits, east countSide allUnits, resistance countside allUnits, civilian countSide allUnits, count playableUnits]
     };
     case 1: {
-        format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", count (allUnits select {simulationEnabled _x}), count (allUnits select {!simulationEnabled _x}), count agents, diag_fps]
+        format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", count (allUnits - playableUnits select {simulationEnabled _x}), count (allUnits select {!simulationEnabled _x}), count agents, diag_fps]
     };
 };

--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -14,22 +14,22 @@
  * Report <STRING>
  *
  * Example:
- * [0] call TAC_Mission_fnc_monitorUnits
+ * [0] call MFUNC(monitorUnits)
  */
 
 params [["_type", 0]];
 
 switch (_type) do {
     case 0: {
-        private _west = west countSide allUnits - playableUnits;
-        private _east = east countSide allUnits - playableUnits;
-        private _resistance = resistance countSide allUnits - playableUnits;
-        private _civilian = civilian countside allUnits - playableUnits;
+        private _west = (west countSide allUnits) - (count playableUnits);
+        private _east = (east countSide allUnits) - (count playableUnits);
+        private _resistance = (resistance countSide allUnits) - (count playableUnits);
+        private _civilian = (civilian countside allUnits) - (count playableUnits);
         format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", _west, _east, _resistance , _civilian, count playableUnits]
     };
     case 1: {
-        private _active = count (allUnits - playableUnits select {simulationEnabled _x});
-        private _inactive = count (allUnits select {!simulationEnabled _x});
+        private _active = count (allUnits select {simulationEnabled _x}) - count playableUnits;
+        private _inactive = count allUnits select {!simulationEnabled _x});
         format ["Active: %1|Inactive: %2|Agents: %3|FPS: %4", _active, _inactive, count agents, diag_fps]
     };
 };


### PR DESCRIPTION
- Removes `playableUnits` from all counters (already has a player counter)
- Separates out checks into variables
- Now does simple numbers instead of array operations (faster)