### PR TITLE
Mission - Rework Respirator Effects and Add Contamination Gas

### DIFF
--- a/addons/mission/XEH_PREP.hpp
+++ b/addons/mission/XEH_PREP.hpp
@@ -11,6 +11,7 @@ PREP(unconscious);
 PREP(bomber);
 PREP(caves);
 PREP(connectBatteryToDefusable);
+PREP(contaminationGas);
 PREP(d30Strike);
 PREP(dialogue);
 PREP(dialogueLocal);

--- a/addons/mission/functions/fnc_contaminationGas.sqf
+++ b/addons/mission/functions/fnc_contaminationGas.sqf
@@ -1,13 +1,13 @@
 #include "script_component.hpp"
 /*
  * Author: Mike
- * Adds contamination gas within a marker radius
+ * Adds contamination gas within a marker radius.
  *
  * Call from initServer.sqf.
  *
  * Arguments:
  * 0: Marker <STRING>
- * 1: Colour <RGBA ARRAY> (default: [1, 1, 0, 0.06])
+ * 1: Colour RGBA <ARRAY> (default: [1, 1, 0, 0.06])
  *
  * Return Value:
  * None
@@ -17,7 +17,7 @@
  * ["MyMarker", [1, 1, 1, 0.04]] call MFUNC(contaminationGas)
  */
 
-params ["_Marker", ["_colour", [1, 1, 0, 0.06]]];
+params ["_marker", ["_colour", [1, 1, 0, 0.06]]];
 
 private _markerSize = (getMarkerSize _marker) select 0;
 private _position = getMarkerPos _marker;
@@ -36,8 +36,7 @@ private _fog3 = "#particlesource" createVehicle _position;
     _x setDropInterval 0.035;
 } forEach [_fog1, _fog2, _fog3];
 
-if (is3DENPreview) then {
-    if (_markerSize >= 60) then {
+if (is3DENPreview && {_markerSize >= 60}) then {
         hint format ["[Contamination Gas]: Marker size (%1) larger than recommended size (60x60).", _markerSize];
     };
 };

--- a/addons/mission/functions/fnc_contaminationGas.sqf
+++ b/addons/mission/functions/fnc_contaminationGas.sqf
@@ -3,7 +3,7 @@
  * Author: Mike
  * Adds contamination gas within a marker radius.
  *
- * Call from initServer.sqf.
+ * Call from initPlayerLocal.sqf.
  *
  * Arguments:
  * 0: Marker <STRING>
@@ -21,9 +21,9 @@ params ["_marker", ["_colour", [1, 1, 0, 0.06]]];
 
 private _markerSize = (getMarkerSize _marker) select 0;
 private _position = getMarkerPos _marker;
-private _fog1 = "#particlesource" createVehicle _position;
-private _fog2 = "#particlesource" createVehicle _position;
-private _fog3 = "#particlesource" createVehicle _position;
+private _fog1 = "#particlesource" createVehicleLocal _position;
+private _fog2 = "#particlesource" createVehicleLocal _position;
+private _fog3 = "#particlesource" createVehicleLocal _position;
 
 {
     _x setParticleParams [

--- a/addons/mission/functions/fnc_contaminationGas.sqf
+++ b/addons/mission/functions/fnc_contaminationGas.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/*
+ * Author: Mike
+ * Adds contamination gas within a marker radius
+ *
+ * Call from initServer.sqf.
+ *
+ * Arguments:
+ * 0: Marker <STRING>
+ * 1: Colour <RGBA ARRAY> (default: [1, 1, 0, 0.06])
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["MyMarker"] call MFUNC(contaminationGas)
+ * ["MyMarker", [1, 1, 1, 0.04]] call MFUNC(contaminationGas)
+ */
+
+params ["_Marker", ["_colour", [1, 1, 0, 0.06]]];
+
+private _markerSize = (getMarkerSize _marker) select 0;
+private _position = getMarkerPos _marker;
+private _fog1 = "#particlesource" createVehicle _position;
+private _fog2 = "#particlesource" createVehicle _position;
+private _fog3 = "#particlesource" createVehicle _position;
+
+{
+    _x setParticleParams [
+    ["\A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 12, 13, 0], "", "Billboard", 1, 10,
+        [0, 0, -6], [0, 0, 0], 1, 1.275, 1, 0,
+        [7,6], [[1, 1, 1, 0], _colour, [1, 1, 1, 0]], [1000], 1, 0, "", "", _x
+    ];
+    _x setParticleRandom [3, [55, 55, 0.2], [0, 0, -0.1], 2, 0.45, [0, 0, 0, 0.1], 0, 0];
+    _x setParticleCircle [_markerSize, [0, 0, -0.12]];
+    _x setDropInterval 0.035;
+} forEach [_fog1, _fog2, _fog3];
+
+if (is3DENPreview) then {
+    if (_markerSize >= 60) then {
+        hint format ["[Contamination Gas]: Marker size (%1) larger than recommended size (60x60).", _markerSize];
+    };
+};

--- a/addons/mission/functions/fnc_contaminationGas.sqf
+++ b/addons/mission/functions/fnc_contaminationGas.sqf
@@ -37,6 +37,5 @@ private _fog3 = "#particlesource" createVehicle _position;
 } forEach [_fog1, _fog2, _fog3];
 
 if (is3DENPreview && {_markerSize >= 60}) then {
-        hint format ["[Contamination Gas]: Marker size (%1) larger than recommended size (60x60).", _markerSize];
-    };
+    hint format ["[Contamination Gas]: Marker size (%1) larger than recommended size (60x60).", _markerSize];
 };

--- a/addons/mission/functions/fnc_respiratorEffects.sqf
+++ b/addons/mission/functions/fnc_respiratorEffects.sqf
@@ -50,7 +50,7 @@ GVAR(oldGlasses) = "";
         };
 
         // Damage
-        if (_markers findIf {_player inArea _x} == 0 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
+        if (_markers findIf {_player inArea _x} > -1 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
             GVAR(maskCounter) = CBA_missionTime;
 
             private _bodypart = selectRandom ["Head", "Body"];

--- a/addons/mission/functions/fnc_respiratorEffects.sqf
+++ b/addons/mission/functions/fnc_respiratorEffects.sqf
@@ -29,6 +29,8 @@ GVAR(oldGlasses) = "";
 #define MASKS ["g_airpurifyingrespirator_01_f", "g_airpurifyingrespirator_02_black_f", "g_airpurifyingrespirator_02_olive_f", "g_airpurifyingrespirator_02_sand_f", "g_regulatormask_f"]
 
 [{
+    params ["_player", "_markers"];
+
     private _goggles = toLower (goggles _player);
 
     if (_goggles in MASKS) then {
@@ -50,7 +52,7 @@ GVAR(oldGlasses) = "";
         };
 
         // Damage
-        if (_markers findIf {_player inArea _x} > -1 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
+        if (_markers findIf {_player inArea _x} >= 0 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
             GVAR(maskCounter) = CBA_missionTime;
 
             private _bodypart = selectRandom ["Head", "Body"];
@@ -59,4 +61,4 @@ GVAR(oldGlasses) = "";
     };
 
     GVAR(oldGlasses) = _goggles;
-} , 1, []] call CBA_fnc_addPerFrameHandler;
+} , 1, [_player, _markers]] call CBA_fnc_addPerFrameHandler;

--- a/addons/mission/functions/fnc_respiratorEffects.sqf
+++ b/addons/mission/functions/fnc_respiratorEffects.sqf
@@ -2,21 +2,24 @@
 /*
  * Author: Alganthe, Mike
  * Specified masks protect from a contamination zone while providing HUD/Sound effects.
- * Requires a marker covering an area named "Contamination" for damage to take effect.
+ * Requires a marker covering an area named for damage to take effect. Can be used for multiple marker zones.
+ * Provides Burn damage on Head/Torso if inside a zone without a mask.
  *
  * Call from initPlayerLocal.sqf
  *
  * Arguments:
  * 0: Player <OBJECT>
+ * 1: Markers <ARRAY>
  *
  * Return Value:
  * None
  *
  * Example:
- * [_player] call MFUNC(respiratorEffects)
+ * [_player, ["MyMarker"]] call MFUNC(respiratorEffects)
+ * [_player, ["MyMarker", "MyMarkerTwo"]] call MFUNC(respiratorEffects)
  */
 
-params ["_player"];
+params ["_player", "_markers"];
 
 GVAR(maskCounter) =  CBA_missionTime;
 GVAR(lastSoundRan) = CBA_missionTime;
@@ -26,10 +29,10 @@ GVAR(oldGlasses) = "";
 #define MASKS ["g_airpurifyingrespirator_01_f", "g_airpurifyingrespirator_02_black_f", "g_airpurifyingrespirator_02_olive_f", "g_airpurifyingrespirator_02_sand_f", "g_regulatormask_f"]
 
 [{
-    private _goggles = toLower (goggles ACE_player);
+    private _goggles = toLower (goggles _player);
 
     if (_goggles in MASKS) then {
-        // Breathing effect, adjust to fit sound length.
+        // Breathing effect
         if (GVAR(lastSoundRan) + 3 < CBA_missionTime) then {
             GVAR(lastSoundRan) = CBA_missionTime;
             playSound "tacr_gasmask_breath";
@@ -46,11 +49,11 @@ GVAR(oldGlasses) = "";
             "tacr_gasmask_overlay" cutFadeOut 0;
         };
         // Damage
-        if (ACE_player inArea "Contamination" && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
+        if (_markers findIf {_player inArea _x} && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
             GVAR(maskCounter) = CBA_missionTime;
-            // Adjust damage / remove body parts to fit your needs.
-            private _bodypart = selectRandom ["Head", "Body", "LeftArm", "RightArm", "LeftLeg", "RightLeg"];
-            [ACE_player, 0.15, _bodyPart, "stab"] call ACEFUNC(medical,addDamageToUnit);
+
+            private _bodypart = selectRandom ["Head", "Body"];
+            [_player, 0.15, _bodyPart, "burn"] call ACEFUNC(medical,addDamageToUnit);
         };
     };
 

--- a/addons/mission/functions/fnc_respiratorEffects.sqf
+++ b/addons/mission/functions/fnc_respiratorEffects.sqf
@@ -29,7 +29,8 @@ GVAR(oldGlasses) = "";
 #define MASKS ["g_airpurifyingrespirator_01_f", "g_airpurifyingrespirator_02_black_f", "g_airpurifyingrespirator_02_olive_f", "g_airpurifyingrespirator_02_sand_f", "g_regulatormask_f"]
 
 [{
-    params ["_player", "_markers"];
+    params ["_args", "_handle"];
+    _args params ["_player", "_markers"];
 
     private _goggles = toLower (goggles _player);
 
@@ -52,7 +53,7 @@ GVAR(oldGlasses) = "";
         };
 
         // Damage
-        if (_markers findIf {_player inArea _x} >= 0 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
+        if ((_markers findIf {_player inArea _x}) >= 0 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
             GVAR(maskCounter) = CBA_missionTime;
 
             private _bodypart = selectRandom ["Head", "Body"];

--- a/addons/mission/functions/fnc_respiratorEffects.sqf
+++ b/addons/mission/functions/fnc_respiratorEffects.sqf
@@ -48,8 +48,9 @@ GVAR(oldGlasses) = "";
             playSound "tacr_gasmask_off";
             "tacr_gasmask_overlay" cutFadeOut 0;
         };
+
         // Damage
-        if (_markers findIf {_player inArea _x} && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
+        if (_markers findIf {_player inArea _x} == 0 && {GVAR(maskCounter) + 10 < CBA_missionTime}) then {
             GVAR(maskCounter) = CBA_missionTime;
 
             private _bodypart = selectRandom ["Head", "Body"];


### PR DESCRIPTION
- Respirator effects now only targets the Head & Torso with burn damage from ACE.
- Now takes an array of markers instead of a singular hardcoded one.
- Uses `_player` param instead of `ACE_player` everywhere.

- Contamination Gas creates visible orange gas within an area. It looks really cool and compliments respirator effects properly.
- Differs from Ground Fog by covering a specific area instead of following you like we did before.