### PR TITLE
Mission - Fix incorrect Monitor Units counts with players

### DIFF
--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -21,15 +21,10 @@ params [["_type", 0]];
 
 switch (_type) do {
     case 0: {
-        private _playersWest = count (playableUnits select {(side _x) == west});
-        private _playersEast = count (playableUnits select {(side _x) == east});
-        private _playersResistance = count (playableUnits select {(side _x) == resistance});
-        private _playersCivilian = count (playableUnits select {(side _x) == civilian});
-
-        private _west = (west countSide allUnits) - _playersWest;
-        private _east = (east countSide allUnits) - _playersEast;
-        private _resistance = (resistance countSide allUnits) - _playersResistance;
-        private _civilian = (civilian countside allUnits) - _playersCivilian;
+        private _west = (west countSide allUnits) - (west countSide playableUnits);
+        private _east = (east countSide allUnits) - (east countSide playableUnits);
+        private _resistance = (resistance countSide allUnits) - (resistance countSide playableUnits);
+        private _civilian = (civilian countside allUnits) - (civilian countSide playableUnits);
         format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", _west, _east, _resistance , _civilian, count playableUnits]
     };
     case 1: {

--- a/addons/mission/functions/fnc_monitorUnits.sqf
+++ b/addons/mission/functions/fnc_monitorUnits.sqf
@@ -21,10 +21,15 @@ params [["_type", 0]];
 
 switch (_type) do {
     case 0: {
-        private _west = (west countSide allUnits) - (count playableUnits);
-        private _east = (east countSide allUnits) - (count playableUnits);
-        private _resistance = (resistance countSide allUnits) - (count playableUnits);
-        private _civilian = (civilian countside allUnits) - (count playableUnits);
+        private _playersWest = count (playableUnits select {(side _x) == west});
+        private _playersEast = count (playableUnits select {(side _x) == east});
+        private _playersResistance = count (playableUnits select {(side _x) == resistance});
+        private _playersCivilian = count (playableUnits select {(side _x) == civilian});
+
+        private _west = (west countSide allUnits) - _playersWest;
+        private _east = (east countSide allUnits) - _playersEast;
+        private _resistance = (resistance countSide allUnits) - _playersResistance;
+        private _civilian = (civilian countside allUnits) - _playersCivilian;
         format ["West: %1|East: %2|Indep: %3|Civ: %4|Player: %5", _west, _east, _resistance , _civilian, count playableUnits]
     };
     case 1: {


### PR DESCRIPTION
- Currently counts `playableUnits` and subtracts it from all sides where there are no players. No longer does that.

Not overly important as it's mostly used in the editor.