### PR TITLE
Update ACE3 translation guide URL

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -17,7 +17,7 @@ from pygithub3 import Github
 
 
 TRANSLATIONISSUE = 51
-TRANSLATIONBODY = """**[ACE3 Translation Guide](http://ace3mod.com/wiki/development/how-to-translate-ace3.html)**
+TRANSLATIONBODY = """**[ACE3 Translation Guide](https://ace3.acemod.org/wiki/development/how-to-translate-ace3.html)**
 (Keep in mind, TAC Mods project and repository information is different!)
 
 {}


### PR DESCRIPTION
ACE3 has a "new" domain - fixed URL for translation.