### PR TITLE
Mission - Add `countAlive` function

### DIFF
--- a/addons/mission/XEH_PREP.hpp
+++ b/addons/mission/XEH_PREP.hpp
@@ -8,11 +8,11 @@ PREP(reinforcements);
 PREP(unconscious);
 
 // Extra
-PREP(aliveInGroups);
 PREP(bomber);
 PREP(caves);
 PREP(connectBatteryToDefusable);
 PREP(contaminationGas);
+PREP(countAlive);
 PREP(d30Strike);
 PREP(dialogue);
 PREP(dialogueLocal);

--- a/addons/mission/XEH_PREP.hpp
+++ b/addons/mission/XEH_PREP.hpp
@@ -8,6 +8,7 @@ PREP(reinforcements);
 PREP(unconscious);
 
 // Extra
+PREP(aliveInGroups);
 PREP(bomber);
 PREP(caves);
 PREP(connectBatteryToDefusable);

--- a/addons/mission/functions/fnc_aliveInGroups.sqf
+++ b/addons/mission/functions/fnc_aliveInGroups.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*
+ * Author: Mike
+ * Returns count of alive units in given groups
+ *
+ * Arguments:
+ * 0: Groups <ARRAY>
+ *
+ * Return Value:
+ * Number
+ *
+ * Example:
+ * [[My_Group_One, My_Group_Two]] call MFUNC(aliveInGroups);
+ *
+ */
+
+params ["_groups"];
+
+private _array = [];
+
+{
+    _array pushBack (units _x);
+} forEach _groups;
+
+_array = flatten _array;
+private _arrayCount = {alive _x} count _array;
+
+_arrayCount;

--- a/addons/mission/functions/fnc_countAlive.sqf
+++ b/addons/mission/functions/fnc_countAlive.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Mike
- * Returns count of alive units in given groups
+ * Returns count of alive units in given groups.
  *
  * Arguments:
  * 0: Groups <ARRAY>

--- a/addons/mission/functions/fnc_countAlive.sqf
+++ b/addons/mission/functions/fnc_countAlive.sqf
@@ -7,22 +7,19 @@
  * 0: Groups <ARRAY>
  *
  * Return Value:
- * Number
+ * Count of alive units <NUMBER>
  *
  * Example:
- * [[My_Group_One, My_Group_Two]] call MFUNC(aliveInGroups);
+ * [[My_Group_One, My_Group_Two]] call MFUNC(countAlive);
  *
  */
 
 params ["_groups"];
 
-private _array = [];
+private _count = 0;
 
 {
-    _array pushBack (units _x);
+    _count = _count + ({alive _x} count units _x);
 } forEach _groups;
 
-_array = flatten _array;
-private _arrayCount = {alive _x} count _array;
-
-_arrayCount;
+_count


### PR DESCRIPTION
- Counts alive units in array of groups. Useful for checking remaining AI for reinforcements and such.

Used it [here](https://github.com/Theseus-Aegis/MissionReviews/blob/door-kickers/tac_co_DoorKickers.SefrouRamal/initServer.sqf#L39-L41) for example.