### PR TITLE
UI Tweaks - Collapse categories by default in Eden

### DIFF
--- a/addons/ui_tweaks/Display3DEN.hpp
+++ b/addons/ui_tweaks/Display3DEN.hpp
@@ -9,35 +9,35 @@ class Display3DEN {
                         class Create: ctrlControlsGroupNoScrollbars {
                             class Controls {
                                 class CreateObjectWEST: ctrlTree {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateObjectEAST: CreateObjectWEST {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateObjectGUER: CreateObjectWEST {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateObjectCIV: CreateObjectWEST {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateObjectEMPTY;
                                 class CreateGroupWEST: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateGroupEAST: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateGroupGUER: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateGroupCIV: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateObjectLogic: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                                 class CreateMarkerIcon: CreateObjectEMPTY {
-                                    defaultItem[]={};
+                                    defaultItem[] = {};
                                 };
                             };
                         };

--- a/addons/ui_tweaks/Display3DEN.hpp
+++ b/addons/ui_tweaks/Display3DEN.hpp
@@ -1,0 +1,49 @@
+class ctrlTree;
+class ctrlControlsGroupNoScrollbars;
+class Display3DEN {
+    class Controls {
+        class PanelRight: ctrlControlsGroupNoScrollbars {
+            class Controls {
+                class PanelRightCreate: ctrlControlsGroupNoScrollbars {
+                    class Controls {
+                        class Create: ctrlControlsGroupNoScrollbars {
+                            class Controls {
+                                class CreateObjectWEST: ctrlTree {
+                                    defaultItem[]={};
+                                };
+                                class CreateObjectEAST: CreateObjectWEST {
+                                    defaultItem[]={};
+                                };
+                                class CreateObjectGUER: CreateObjectWEST {
+                                    defaultItem[]={};
+                                };
+                                class CreateObjectCIV: CreateObjectWEST {
+                                    defaultItem[]={};
+                                };
+                                class CreateObjectEMPTY;
+                                class CreateGroupWEST: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                                class CreateGroupEAST: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                                class CreateGroupGUER: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                                class CreateGroupCIV: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                                class CreateObjectLogic: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                                class CreateMarkerIcon: CreateObjectEMPTY {
+                                    defaultItem[]={};
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/ui_tweaks/config.cpp
+++ b/addons/ui_tweaks/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"A3_Ui_F"};
+        requiredAddons[] = {"A3_Ui_F", "A3_3DEN"};
         author = ECSTRING(main,Author);
         authors[] = {"Drofseh"};
         url = ECSTRING(main,URL);
@@ -15,3 +15,4 @@ class CfgPatches {
 };
 
 #include "RscDisplay.hpp"
+#include "Display3DEN.hpp"


### PR DESCRIPTION
- Been looking to do this for ages, it bothers me that it automatically expands categories in the editor and now it no longer does.