### PR TITLE
Optionals - Add Aegis ACE Hearing

### DIFF
--- a/optionals/aegis_ace_hearing/$PBOPREFIX$
+++ b/optionals/aegis_ace_hearing/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\aegis_ace_hearing

--- a/optionals/aegis_ace_hearing/CfgWeapons.hpp
+++ b/optionals/aegis_ace_hearing/CfgWeapons.hpp
@@ -1,0 +1,71 @@
+#define MACRO_HEARING \
+        ace_hearing_protection = 0.75; \
+        ace_hearing_lowerVolume = 0; \
+
+class CfgWeapons {
+    class H_HelmetI_I_01_cover_base_F;
+    class H_HelmetI_I_01_cover_F: H_HelmetI_I_01_cover_base_F {
+        MACRO_HEARING
+    };
+
+    class H_HelmetI_I_01_base_F;
+    class H_HelmetI_I_01_F: H_HelmetI_I_01_base_F {
+        MACRO_HEARING
+    };
+
+    class H_HelmetPunisher_base_F;
+    class H_HelmetPunisher_cover_green_F: H_HelmetPunisher_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetPunisher_headset_green_F: H_HelmetPunisher_base_F {
+        MACRO_HEARING
+    };
+
+    class H_HelmetSpecter_headset_base_F;
+    class H_HelmetSpecter_black_headset_F: H_HelmetSpecter_headset_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetSpecter_brown_headset_F: H_HelmetSpecter_headset_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetSpecter_headset_F: H_HelmetSpecter_headset_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetSpecter_paint_headset_F: H_HelmetSpecter_headset_base_F {
+        MACRO_HEARING
+    };
+
+    class H_HelmetSpecter_cover_base_F;
+    class H_HelmetSpecter_cover_khaki_F: H_HelmetSpecter_cover_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetSpecter_cover_taiga_F: H_HelmetSpecter_cover_base_F {
+        MACRO_HEARING
+    };
+    class H_HelmetSpecter_cover_UNO_F: H_HelmetSpecter_cover_base_F {
+        MACRO_HEARING
+    };
+    class rev_H_HelmetSpecter_cover_whex_CO: H_HelmetSpecter_cover_base_F {
+        MACRO_HEARING
+    };
+
+    class H_MK7_Base_F;
+    class H_MK7_AAF_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+    class H_MK7_atacsfg_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+    class H_MK7_Marar_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+    class H_MK7_oli_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+    class H_MK7_sand_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+    class H_MK7_UN_F: H_MK7_Base_F {
+        MACRO_HEARING
+    };
+};

--- a/optionals/aegis_ace_hearing/README.md
+++ b/optionals/aegis_ace_hearing/README.md
@@ -1,0 +1,7 @@
+# About
+
+Adds [ACE3 Hearing](http://ace3mod.com/wiki/feature/hearing.html) support to headgear from [Aegis](https://steamcommunity.com/workshop/filedetails/?id=949252631) mod by Avery.
+
+### Authors
+
+- [Mike](https://github.com/mike-mf)

--- a/optionals/aegis_ace_hearing/config.cpp
+++ b/optionals/aegis_ace_hearing/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "tac_main",
+            "ace_hearing",
+            "A3_Aegis_Characters_F_Aegis_Headgear",
+            "A3_athena_Characters_F_athena_Headgear",
+            "A3_Atlas_Characters_F_Atlas_Headgear",
+            "A3_revolucion_Characters_F_revolucion_Headgear"
+        };
+        author = ECSTRING(main,Author);
+        authors[] = {"Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/optionals/aegis_ace_hearing/config.cpp
+++ b/optionals/aegis_ace_hearing/config.cpp
@@ -17,7 +17,6 @@ class CfgPatches {
         authors[] = {"Mike"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
-        skipWhenMissingDependencies = 1;
     };
 };
 

--- a/optionals/aegis_ace_hearing/script_component.hpp
+++ b/optionals/aegis_ace_hearing/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT aegis_ace_hearing
+#define COMPONENT_BEAUTIFIED Aegis ACE3 Hearing
+#include "\x\tac\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_AEGIS_ACE_HEARING
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_AEGIS_ACE_HEARING
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_AEGIS_ACE_HEARING
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"


### PR DESCRIPTION
- Adds ACE hearing properties to helmets that need it.
- Adds `skipWhenMissingDependencies` so we can throw this into main after version 2.14
- Tested and working.