### PR TITLE
Mission - Add Download Intel function

### DIFF
--- a/addons/mission/XEH_PREP.hpp
+++ b/addons/mission/XEH_PREP.hpp
@@ -16,6 +16,7 @@ PREP(countAlive);
 PREP(dialogue);
 PREP(dialogueLocal);
 PREP(disableAI);
+PREP(downloadIntel);
 PREP(earthquake);
 PREP(enableAI);
 PREP(forceShooting);

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -4,22 +4,24 @@
  * Laptop is hard limited to the "Rugged Laptop" items otherwise alignment is massively off.
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
+ * Texture source is shown on the object via Attributes > Object Specific > Texture #X
  *
  * Call from init.sqf
  *
  * Arguments:
  * 0: Laptop <OBJECT>
- * 1: Filesize <NUMBER>
- * 2: Download Time <NUMBER>
+ * 1: Texture Source <NUMBER>
+ * 2: Filesize <NUMBER>
+ * 3: Download Time <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * [MyGroup] call MFUNC(downloadIntel)
+ * [Laptop, 0, 100, 60] call MFUNC(downloadIntel)
  */
 
-params ["_object", "_fileSize", "_downloadTime"];
+params ["_object", "_textureSource", "_fileSize", "_downloadTime"];
 
 // Initial setup - Players (ACE Action for download start.)
 if (hasInterface) then {
@@ -28,12 +30,17 @@ if (hasInterface) then {
         "Download Intel",
         "",
         {
+            (_this select 2) params ["_textureSource"];
+
             _target setVariable [QGVAR(downloadActive), true, true];
-            _target setObjectTextureGlobal [1, '#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n")'];
+            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n")', floor (random [10000, 30000, 64224])];
+            _target setObjectTextureGlobal [_textureSource, _string];
         },
         {
             !(_target getVariable [QGVAR(downloadActive), false]);
-        }
+        },
+        {},
+        [_textureSource]
     ] call ACEFUNC(interact_menu,createAction);
 
     [_object, 0, ["ACE_MainActions"], _action] call ACEFUNC(interact_menu,addActionToObject);
@@ -44,18 +51,20 @@ if (isServer) then {
     // PFH refresh rate
     private _updateTickTime = _downloadTime / 10;
 
-    _object setObjectTextureGlobal [1, '#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n")'];
+    private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n")', floor (random [10000, 30000, 64224])];
+    _object setObjectTextureGlobal [_textureSource, _string];
     _object setVariable [QGVAR(downloadActive), false, true];
     _object setVariable [QGVAR(downloadStage), 0];
 
     // PFH
     [{
         params ["_args", "_handle"];
-        _args params ["_object", "_fileSize"];
+        _args params ["_object", "_fileSize", "_textureSource"];
 
         // Exit if download hasn't yet started.
         if !(_object getVariable [QGVAR(downloadActive), false]) exitWith {};
 
+        private _memory = floor (random [10000, 30000, 64224]);
         private _stage = _object getVariable [QGVAR(downloadStage), 0];
         private _downloaded = _fileSize * (_stage / 100);
         private _progressBar = "[          ]";
@@ -65,22 +74,22 @@ if (isServer) then {
             _progressBar = _progressBar joinString "";
         };
 
-        private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloading: %1/%2GB \n  %3 (%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
+        private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloading: %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
 
-        _object setObjectTextureGlobal [1, _string];
+        _object setObjectTextureGlobal [_textureSource, _string];
 
         _object setVariable [QGVAR(downloadStage), (_stage + 10)];
 
         if (_stage == 100) exitWith {
             _handle call CBA_fnc_removePerFrameHandler;
-            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %1/%2GB \n  %3 (%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
-            _object setObjectTextureGlobal [1, _string];
+            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
+            _object setObjectTextureGlobal [_textureSource, _string];
 
             // Blank out screen
             [{
-                _this #1 setObjectTextureGlobal [1, ""];
-            }, [_object], 10] call CBA_fnc_waitAndExecute;
+                (_this select 0) setObjectTextureGlobal [(_this select 1), "#(argb,8,8,3)color(0,0,0,0,co)"];
+            }, [_object, _textureSource], 10] call CBA_fnc_waitAndExecute;
         };
 
-    }, _updateTickTime, [_object, _fileSize]] call CBA_fnc_addPerFrameHandler;
+    }, _updateTickTime, [_object, _fileSize, _textureSource]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Mike
- * Laptop is hard limited to the "Rugged Laptop" items otherwise alignment is massively off.
+ * Only Laptop, Rugged Laptop & PC Set - Screen are actively supported.
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
  * Texture source is shown on the object via Attributes > Object Specific > Texture #X

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -1,0 +1,86 @@
+#include "script_component.hpp"
+/*
+ * Author: Mike
+ * Laptop is hard limited to the "Rugged Laptop" items otherwise alignment is massively off.
+ * Has a laptop generate an intel download after an ACE interaction.
+ * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / fileSize
+ *
+ * Call from init.sqf
+ *
+ * Arguments:
+ * 0: Laptop <OBJECT>
+ * 1: Filesize <NUMBER>
+ * 2: Download Time <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [MyGroup] call MFUNC(downloadIntel)
+ */
+
+params ["_object", "_fileSize", "_downloadTime"];
+
+// PFH refresh rate
+private _updateTickTime = _downloadTime / _fileSize;
+
+// Initial setup - Players (ACE Action for download start.)
+if (hasInterface) then {
+    private _action = [
+        QGVAR(downloadIntel),
+        "Download Intel",
+        "",
+        {
+            _target setVariable [QGVAR(downloadActive), true, true];
+            // Placeholder for now. (Write files to external drive, wipe drive afterwards?)
+            _target setObjectTextureGlobal [1, '#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","CHANGE ME!")'];
+        },
+        {
+            !(_target getVariable [QGVAR(downloadActive), false]);
+        }
+    ] call ACEFUNC(interact_menu,createAction);
+
+    [_object, 0, ["ACE_MainActions"], _action] call ACEFUNC(interact_menu,addActionToObject);
+};
+
+// Initial setup - Server
+if (isServer) then {
+    // Placeholder for now. (Something resembling Linux)
+    _object setObjectTextureGlobal [1, '#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","CHANGE ME!")'];
+    _object setVariable [QGVAR(downloadActive), false, true];
+    _object setVariable [QGVAR(downloadStage), 0];
+
+    // PFH
+    [{
+        params ["_args", "_handle"];
+        _args params ["_object", "_fileSize"];
+
+        // Exit if download hasn't yet started.
+        if !(_object getVariable [QGVAR(downloadActive), false]) exitWith {};
+
+        private _stage = _object getVariable [QGVAR(downloadStage), 0];
+        private _downloaded = _fileSize * (_stage / 100);
+        private _progressBar = "[]";
+        for "_i" from 1 to (_stage / 10) do {
+            _progressBar = _progressBar insert [1, "="];
+        };
+
+        private _string = format ['#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","Downloading\n %1/%2GB \n%3\n(%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
+
+        _object setObjectTextureGlobal [1, _string];
+
+        _object setVariable [QGVAR(downloadStage), (_stage + 10)];
+
+        if (_stage == 100) exitWith {
+            _handle call CBA_fnc_removePerFrameHandler;
+            private _string = format ['#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","Downloaded\n %1/%2GB \n%3\n(%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
+            _object setObjectTextureGlobal [1, _string];
+
+            // Blank out screen
+            [{
+                _this setObjectTextureGlobal [1, ""];
+            }, [_object], 10] call CBA_fnc_waitAndExecute;
+        };
+
+    }, _updateTickTime, [_object, _fileSize]] call CBA_fnc_addPerFrameHandler;
+};

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -82,6 +82,7 @@ if (isServer) then {
 
         if (_stage == 100) exitWith {
             _handle call CBA_fnc_removePerFrameHandler;
+            ["ocap_customEvent", ["generalEvent", "Intel was downloaded!"]] call CBA_fnc_serverEvent;
             private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
             _object setObjectTextureGlobal [_textureSource, _string];
 

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -4,6 +4,7 @@
  * Laptop is hard limited to the "Rugged Laptop" items otherwise alignment is massively off.
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / fileSize
+ * fileSize should always be above 10.
  *
  * Call from init.sqf
  *
@@ -21,8 +22,9 @@
 
 params ["_object", "_fileSize", "_downloadTime"];
 
-// PFH refresh rate
-private _updateTickTime = _downloadTime / _fileSize;
+if (_fileSize < 10) then {
+    WARNING_1("Filesize (%1) too low, set to a value above 10",_fileSize);
+};
 
 // Initial setup - Players (ACE Action for download start.)
 if (hasInterface) then {
@@ -32,8 +34,7 @@ if (hasInterface) then {
         "",
         {
             _target setVariable [QGVAR(downloadActive), true, true];
-            // Placeholder for now. (Write files to external drive, wipe drive afterwards?)
-            _target setObjectTextureGlobal [1, '#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","CHANGE ME!")'];
+            _target setObjectTextureGlobal [1, '#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n")'];
         },
         {
             !(_target getVariable [QGVAR(downloadActive), false]);
@@ -45,8 +46,10 @@ if (hasInterface) then {
 
 // Initial setup - Server
 if (isServer) then {
-    // Placeholder for now. (Something resembling Linux)
-    _object setObjectTextureGlobal [1, '#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","CHANGE ME!")'];
+    // PFH refresh rate
+    private _updateTickTime = _downloadTime / _fileSize;
+
+    _object setObjectTextureGlobal [1, '#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n")'];
     _object setVariable [QGVAR(downloadActive), false, true];
     _object setVariable [QGVAR(downloadStage), 0];
 
@@ -60,12 +63,14 @@ if (isServer) then {
 
         private _stage = _object getVariable [QGVAR(downloadStage), 0];
         private _downloaded = _fileSize * (_stage / 100);
-        private _progressBar = "[]";
+        private _progressBar = "[          ]";
         for "_i" from 1 to (_stage / 10) do {
-            _progressBar = _progressBar insert [1, "="];
+            _progressBar = _progressBar splitString "";
+            _progressBar set [_i, "="];
+            _progressBar = _progressBar joinString "";
         };
 
-        private _string = format ['#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","Downloading\n %1/%2GB \n%3\n(%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
+        private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloading: %1/%2GB \n  %3 (%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
 
         _object setObjectTextureGlobal [1, _string];
 
@@ -73,12 +78,12 @@ if (isServer) then {
 
         if (_stage == 100) exitWith {
             _handle call CBA_fnc_removePerFrameHandler;
-            private _string = format ['#(rgb,512,512,3)text(1,1,"RobotoCondensedBold",0.1,"#000000","#ff0000","Downloaded\n %1/%2GB \n%3\n(%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
+            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %1/%2GB \n  %3 (%4%5)")', _downloaded, _fileSize, _progressBar, _stage, "%"];
             _object setObjectTextureGlobal [1, _string];
 
             // Blank out screen
             [{
-                _this setObjectTextureGlobal [1, ""];
+                _this #1 setObjectTextureGlobal [1, ""];
             }, [_object], 10] call CBA_fnc_waitAndExecute;
         };
 

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -5,6 +5,7 @@
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
  * Texture source is shown on the object via Attributes > Object Specific > Texture #X
+ * Can use getVariable on the laptop to check if download is complete with QGVAR(downloadComplete)
  *
  * Call from init.sqf
  *
@@ -85,6 +86,7 @@ if (isServer) then {
             ["ocap_customEvent", ["generalEvent", "Intel was downloaded!"]] call CBA_fnc_serverEvent;
             private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
             _object setObjectTextureGlobal [_textureSource, _string];
+            _object setVariable [QGVAR(downloadComplete), true, true];
 
             // Blank out screen
             [{

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: Mike
+ * Author: Mike, Jonpas
  * Only Laptop, Rugged Laptop & PC Set - Screen are actively supported.
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
@@ -24,24 +24,17 @@
 
 params ["_object", "_textureSource", "_fileSize", "_downloadTime"];
 
-// Initial setup - Players (ACE Action for download start.)
+#define WEEKDAYS ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+#define MONTHS ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+// Initial setup - Players (ACE Action for download start)
 if (hasInterface) then {
     private _action = [
         QGVAR(downloadIntel),
         "Download Intel",
         "",
-        {
-            (_this select 2) params ["_textureSource"];
-
-            _target setVariable [QGVAR(downloadActive), true, true];
-            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n")', floor (random [10000, 30000, 64224])];
-            _target setObjectTextureGlobal [_textureSource, _string];
-        },
-        {
-            !(_target getVariable [QGVAR(downloadActive), false]);
-        },
-        {},
-        [_textureSource]
+        {_target setVariable [QGVAR(downloadIntel_active), true, true]},
+        {!(_target getVariable [QGVAR(downloadIntel_active), false])}
     ] call ACEFUNC(interact_menu,createAction);
 
     [_object, 0, ["ACE_MainActions"], _action] call ACEFUNC(interact_menu,addActionToObject);
@@ -49,50 +42,136 @@ if (hasInterface) then {
 
 // Initial setup - Server
 if (isServer) then {
-    // PFH refresh rate
-    private _updateTickTime = _downloadTime / 10;
+    private _fnc_randomLastLoginDate = {
+        private _date = date;
+        private _dateNumber = dateToNumber _date;
+        _dateNumber = _dateNumber - ((1 / 365 / 24) * random 23);
+        _date = numberToDate [_date select 0, _dateNumber];
 
-    private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n")', floor (random [10000, 30000, 64224])];
-    _object setObjectTextureGlobal [_textureSource, _string];
-    _object setVariable [QGVAR(downloadActive), false, true];
-    _object setVariable [QGVAR(downloadStage), 0];
+        _date params ["_year", "_month", "_day", "_hours", "_minutes"];
+        _hours = [_hours, 2] call CBA_fnc_formatNumber;
+        _minutes = [_minutes, 2] call CBA_fnc_formatNumber;
 
-    // PFH
+        private _seconds = [floor random 59, 2] call CBA_fnc_formatNumber;
+        private _weekDay = WEEKDAYS select ([_date] call CBA_fnc_weekDay);
+        private _month = MONTHS select (_month - 1);
+
+        [_weekDay, _month, _day, _hours, _minutes, _seconds]
+    };
+    (call _fnc_randomLastLoginDate) params ["_weekDay", "_month", "_day", "_hours", "_minutes", "_seconds"];
+
+    private _terminalLogin = " loki login:";
+    private _terminalPrepare = [
+        [
+            format ["%1 Ligma", _terminalLogin],
+            " Password:",
+            "" // replaced with next
+        ], [
+            format [" Last Login: %1 %2 %3 %4:%5:%6 on ttyl", _weekDay, _month, _day, _hours, _minutes, _seconds],
+            " $" // replaced with next
+        ], [
+            " $ sysinfo",
+            "    Ligma@loki",
+            "    -----------",
+            "    OS: Arch Linux x86_64",
+            "    Host: 23475K3 ThinkPad T430",
+            "    Kernel: 6.4.8-arch1-1",
+            "    Packages: 1277 (pacman)",
+            "    Shell: zsh 5.9",
+            "    Resolution: 1600x900",
+            "    WM: i3",
+            "    Theme: Equilux [GTK2/3]",
+            "    Icons: Papirus-Dark [GTK2/3]",
+            "    Terminal: kitty",
+            "    CPU: Intel i5-3320M (4) @ 3.300GHz",
+            "    GPU: Intel Graphics Controller",
+            "    Memory: 9238MiB / 15258MiB",
+            "",
+            " $" // replaced with next
+        ], [
+            " $ mkdir -p /mnt/usb",
+            " $" // replaced with next
+        ], [
+            " $ mount /dev/sdb1 /mnt/usb",
+            " $" // replaced with next
+        ], [
+            " $ /mnt/usb/tyrone.py /home/ligma/confidential --wipe",
+            "",
+            "     Preparing...",
+            "",
+            "" // replaced with next
+        ]
+    ];
+
+    private _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminalLogin];
+    _object setObjectTextureGlobal [_textureSource, _texture];
+    _object setVariable [QGVAR(downloadIntel_active), false, true];
+    _object setVariable [QGVAR(downloadIntel_stage), -1];
+    _object setVariable [QGVAR(downloadIntel_prepareStage), 0];
+
     [{
         params ["_args", "_handle"];
-        _args params ["_object", "_fileSize", "_textureSource"];
+        _args params ["_lastTime", "_terminal", "_object", "_fileSize", "_textureSource", "_downloadTime", "_terminalPrepare"];
 
-        // Exit if download hasn't yet started.
-        if !(_object getVariable [QGVAR(downloadActive), false]) exitWith {};
+        // Exit if download hasn't yet started
+        if !(_object getVariable [QGVAR(downloadIntel_active), false]) exitWith {};
 
-        private _memory = floor (random [10000, 30000, 64224]);
-        private _stage = _object getVariable [QGVAR(downloadStage), 0];
-        private _downloaded = _fileSize * (_stage / 100);
+        private _stage = _object getVariable [QGVAR(downloadIntel_stage), -1];
+
+        // Prepare
+        if (_stage < 0) exitWith {
+            // 2s tick rate
+            if (_lastTime + 2 > CBA_missionTime) exitWith {};
+            _args set [0, CBA_missionTime];
+
+            private _prepareStage = _object getVariable [QGVAR(downloadIntel_prepareStage), 0];
+
+            _terminal deleteAt (count _terminal - 1);
+            _terminal append (_terminalPrepare select _prepareStage);
+
+            private _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminal joinString "\n"];
+            _object setObjectTextureGlobal [_textureSource, _texture];
+            _object setVariable [QGVAR(downloadIntel_prepareStage), _prepareStage + 1];
+
+            if (_prepareStage + 1 >= count _terminalPrepare) then {
+                _object setVariable [QGVAR(downloadIntel_stage), _stage + 1];
+            };
+        };
+
+        // Follow wanted download (tick) rate from here
+        if (_lastTime + _downloadTime > CBA_missionTime) exitWith {};
+        _args set [0, CBA_missionTime];
+
+        // Download
+        private _downloaded = _fileSize * (_stage / 10);
         private _progressBar = "[          ]";
-        for "_i" from 1 to (_stage / 10) do {
+        for "_i" from 1 to _stage do {
             _progressBar = _progressBar splitString "";
             _progressBar set [_i, "="];
             _progressBar = _progressBar joinString "";
         };
 
-        private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloading: %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
+        private _progressString = format ["     %1GB / %2GB  %3 (%4%5)\n", _downloaded, _fileSize, _progressBar, _stage * 10, "%"];
+        _terminal set [-1, _progressString];
+        _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminal joinString "\n"];
+        _object setObjectTextureGlobal [_textureSource, _texture];
+        _object setVariable [QGVAR(downloadIntel_stage), _stage + 1];
 
-        _object setObjectTextureGlobal [_textureSource, _string];
-
-        _object setVariable [QGVAR(downloadStage), (_stage + 10)];
-
-        if (_stage == 100) exitWith {
+        // Finish
+        if (_stage >= 10) exitWith {
             _handle call CBA_fnc_removePerFrameHandler;
             ["ocap_customEvent", ["generalEvent", "Intel was downloaded!"]] call CBA_fnc_serverEvent;
-            private _string = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X  \n GPU: AMD ATI Radeon RX 6800/6800 XT  \n Memory: %1MiB / 64224MiB \n\n  $ sudo mkdir -p /mnt/usb \n  $ sudo mount /dev/sdb1 /mnt/usb \n  /mnt/usb/steal.py /home/fraser/confidential --wipe \n\n  Downloaded:  %2/%3GB \n  %4 (%5%6)")', _memory, _downloaded, _fileSize, _progressBar, _stage, "%"];
-            _object setObjectTextureGlobal [_textureSource, _string];
-            _object setVariable [QGVAR(downloadComplete), true, true];
 
-            // Blank out screen
-            [{
-                (_this select 0) setObjectTextureGlobal [(_this select 1), "#(argb,8,8,3)color(0,0,0,0,co)"];
-            }, [_object, _textureSource], 10] call CBA_fnc_waitAndExecute;
+            private _terminalFinal = [
+                "     Completed",
+                "     Wiping...",
+                "     Remove Device!"
+            ];
+            _terminal append _terminalFinal;
+            _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminal joinString "\n"];
+            _object setObjectTextureGlobal [_textureSource, _texture];
+            _object setVariable [QGVAR(downloadComplete), true, true];
         };
 
-    }, _updateTickTime, [_object, _fileSize, _textureSource]] call CBA_fnc_addPerFrameHandler;
+    }, 0.1, [CBA_missionTime, [], _object, _fileSize, _textureSource, _downloadTime / 10, _terminalPrepare]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -3,8 +3,7 @@
  * Author: Mike
  * Laptop is hard limited to the "Rugged Laptop" items otherwise alignment is massively off.
  * Has a laptop generate an intel download after an ACE interaction.
- * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / fileSize
- * fileSize should always be above 10.
+ * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
  *
  * Call from init.sqf
  *
@@ -21,10 +20,6 @@
  */
 
 params ["_object", "_fileSize", "_downloadTime"];
-
-if (_fileSize < 10) then {
-    WARNING_1("Filesize (%1) too low, set to a value above 10",_fileSize);
-};
 
 // Initial setup - Players (ACE Action for download start.)
 if (hasInterface) then {
@@ -47,7 +42,7 @@ if (hasInterface) then {
 // Initial setup - Server
 if (isServer) then {
     // PFH refresh rate
-    private _updateTickTime = _downloadTime / _fileSize;
+    private _updateTickTime = _downloadTime / 10;
 
     _object setObjectTextureGlobal [1, '#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#000000","#00B200","\n login: loki \n Password: \n user@loki \n ----------- \n OS: Arch Linux x86_64 \n Host: X570 AORUS PRO -CF \n Kernel: 6.4.8-arch1-1 \n Uptime: 44 hours, 12 mins \n Packages: 1767 (pacman), 4 (flatpak) \n Shell: zsh 5.9 \n Resolution: 3440x1440, 2560x1080, 1920x1080 \n WM: i3 \n Theme: Equilux [GTK2/3] \n Icons: Papirus-Dark [GTK2/3] \n Terminal: kitty \n CPU: AMD Ryzen 7 5800X3D (16) @ 4.550GHz \n GPU: AMD ATI Radeon 540/540X/550/550X / RX 540X/550/550X \n GPU: AMD ATI Radeon RX 6800/6800 XT / 6900 XT \n Memory: 39995MiB / 64224MiB \n")'];
     _object setVariable [QGVAR(downloadActive), false, true];

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -5,7 +5,7 @@
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
  * Texture source is shown on the object via Attributes > Object Specific > Texture #X
- * Can use getVariable on the laptop to check if download is complete with QGVAR(downloadIntel_Complete)
+ * Can use getVariable on the laptop to check if download is complete with QGVAR(downloadIntel_complete)
  *
  * Call from init.sqf
  *
@@ -170,7 +170,7 @@ if (isServer) then {
             _terminal append _terminalFinal;
             _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminal joinString "\n"];
             _object setObjectTextureGlobal [_textureSource, _texture];
-            _object setVariable [QGVAR(downloadIntel_Complete), true, true];
+            _object setVariable [QGVAR(downloadIntel_complete), true, true];
         };
 
     }, 0.1, [CBA_missionTime, [], _object, _fileSize, _textureSource, _downloadTime / 10, _terminalPrepare]] call CBA_fnc_addPerFrameHandler;

--- a/addons/mission/functions/fnc_downloadIntel.sqf
+++ b/addons/mission/functions/fnc_downloadIntel.sqf
@@ -5,7 +5,7 @@
  * Has a laptop generate an intel download after an ACE interaction.
  * Will update in increments of 10% until 100. Refresh rate of the download is worked out as downloadTime / 10
  * Texture source is shown on the object via Attributes > Object Specific > Texture #X
- * Can use getVariable on the laptop to check if download is complete with QGVAR(downloadComplete)
+ * Can use getVariable on the laptop to check if download is complete with QGVAR(downloadIntel_Complete)
  *
  * Call from init.sqf
  *
@@ -170,7 +170,7 @@ if (isServer) then {
             _terminal append _terminalFinal;
             _texture = format ['#(rgb,512,512,3)text(0,0,"EtelkaMonospacePro",0.03,"#1A1818","#00B200","%1")', _terminal joinString "\n"];
             _object setObjectTextureGlobal [_textureSource, _texture];
-            _object setVariable [QGVAR(downloadComplete), true, true];
+            _object setVariable [QGVAR(downloadIntel_Complete), true, true];
         };
 
     }, 0.1, [CBA_missionTime, [], _object, _fileSize, _textureSource, _downloadTime / 10, _terminalPrepare]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
- Laptop which can have intel downloaded from it.
- Uses procedural textures to show total filesize and what percentage the download is currently at. Also shows a progress bar like this: `[=====]` (at 50%)
- Ran from per frame handler where the refresh time is done by downloadTime / 10 (download is done in 10 ticks)
- Laptop, Rugged Laptop and PC Set - Screen are supported.
- Texture Source is supported as a param.
- ~~Memory usage is randomised on each tick~~.
- Code now displays with delays to be fancy and simulate typing.
- Day/Time of last use is now randomised.
- Linux heresy is more accurate.
- Initial texture on use moved from ACE action to PFH.

To Do:
- [x] Remove placeholder text when JJ gives me Linuxy things.
- [x] Test / Support other screen types.
- [x] Alter Background colour.
- [x] Alter text colour.
- [x] Test on server with other people.
- [x] OCAP Event
- [x] Variable for download complete