### PR TITLE
Apollo - Add Automatic Server Reset

### DIFF
--- a/addons/apollo/XEH_postInitServer.sqf
+++ b/addons/apollo/XEH_postInitServer.sqf
@@ -20,12 +20,12 @@ publicVariable QGVAR(isDebug);
 // Reset server if map/mission changed from last saved
 private _resetError = false;
 if (GVAR(allowServerReset)) then {
-    private _reset = ["resetServer", GVAR(enabledPlayers), GVAR(enabledVehicles), serverName, worldName, missionName] call FUNC(invokeJavaMethod);
+    private _reset = ["resetServer", GVAR(enabledPlayers), GVAR(enabledVehicles), serverName, worldName, missionNameSource] call FUNC(invokeJavaMethod);
     if (_reset == "error") exitWith {_resetError = true; };
-    if (_reset == "none") exitWith { INFO_3("Server reset not performed (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
-    INFO_3("Server reset successfully (server: %1, map: %2, mission: %3)",serverName,worldName,missionName);
+    if (_reset == "none") exitWith { INFO_3("Server reset not performed (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource); };
+    INFO_3("Server reset successfully (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource);
 };
-if (_resetError) exitWith { ERROR_3("Server failed to reset after map change! (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
+if (_resetError) exitWith { ERROR_3("Server failed to reset after map change! (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource); };
 
 if (GVAR(enabledVehicles)) then {
     call FUNC(vehicleLoad);

--- a/addons/apollo/XEH_postInitServer.sqf
+++ b/addons/apollo/XEH_postInitServer.sqf
@@ -20,12 +20,12 @@ publicVariable QGVAR(isDebug);
 // Reset server if map/mission changed from last saved
 private _resetError = false;
 if (GVAR(allowServerReset)) then {
-    private _reset = ["resetServer", GVAR(enabledPlayers), GVAR(enabledVehicles), serverName, worldName, missionNameSource] call FUNC(invokeJavaMethod);
+    private _reset = ["resetServer", GVAR(enabledPlayers), GVAR(enabledVehicles), serverName, worldName, missionName] call FUNC(invokeJavaMethod);
     if (_reset == "error") exitWith {_resetError = true; };
-    if (_reset == "none") exitWith { INFO_3("Server reset not performed (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource); };
-    INFO_3("Server reset successfully (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource);
+    if (_reset == "none") exitWith { INFO_3("Server reset not performed (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
+    INFO_3("Server reset successfully (server: %1, map: %2, mission: %3)",serverName,worldName,missionName);
 };
-if (_resetError) exitWith { ERROR_3("Server failed to reset after map change! (server: %1, map: %2, mission: %3)",serverName,worldName,missionNameSource); };
+if (_resetError) exitWith { ERROR_3("Server failed to reset after map change! (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
 
 if (GVAR(enabledVehicles)) then {
     call FUNC(vehicleLoad);

--- a/addons/apollo/XEH_postInitServer.sqf
+++ b/addons/apollo/XEH_postInitServer.sqf
@@ -11,8 +11,21 @@ if (_jniVersion != REQUIRED_JNI_VERSION) exitWith {
 
 // Set server type (debug or live) globally
 private _serverType = ["getServerType"] call FUNC(invokeJavaMethod);
+if (_serverType == "error") exitWith {
+    ERROR_1("Failed to initialize - Invalid server type (%1)!",_serverType);
+};
 GVAR(isDebug) = [false, true] select (_serverType isEqualTo "debug");
 publicVariable QGVAR(isDebug);
+
+// Reset server if map/mission changed from last saved
+private _resetError = false;
+if (GVAR(allowServerReset)) then {
+    private _reset = ["resetServer", GVAR(enabledPlayers), GVAR(enabledVehicles), serverName, worldName, missionName] call FUNC(invokeJavaMethod);
+    if (_reset == "error") exitWith {_resetError = true; };
+    if (_reset == "none") exitWith { INFO_3("Server reset not performed (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
+    INFO_3("Server reset successfully (server: %1, map: %2, mission: %3)",serverName,worldName,missionName);
+};
+if (_resetError) exitWith { ERROR_3("Server failed to reset after map change! (server: %1, map: %2, mission: %3)",serverName,worldName,missionName); };
 
 if (GVAR(enabledVehicles)) then {
     call FUNC(vehicleLoad);

--- a/addons/apollo/initSettings.sqf
+++ b/addons/apollo/initSettings.sqf
@@ -30,3 +30,14 @@
     {},
     true
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(allowServerReset),
+    "CHECKBOX",
+    [LSTRING(AllowServerReset), LSTRING(AllowServerResetDesc)],
+    format ["TAC %1", QUOTE(COMPONENT_BEAUTIFIED)],
+    true,
+    true,
+    {},
+    true
+] call CBA_fnc_addSetting;

--- a/addons/apollo/stringtable.xml
+++ b/addons/apollo/stringtable.xml
@@ -26,6 +26,12 @@
             <German>Aktiviert Persistenz für Fahrzeuge.</German>
             <French>Active la persistance pour les véhicules.</French>
         </Key>
+        <Key ID="STR_TAC_Apollo_AllowServerReset">
+            <English>Allow Server Reset</English>
+        </Key>
+        <Key ID="STR_TAC_Apollo_AllowServerResetDesc">
+            <English>Allows resetting player positions and deleting saved vehicles on map or mission change since last save.</English>
+        </Key>
         <Key ID="STR_TAC_Apollo_RespawnReinitialization">
             <English>You are being moved back to lobby for reinitialization.</English>
             <German>Du wirst wegen Neuinitialisierung zurück zur Lobby verschoben.</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #402 
- Call Apollo to reset server data (map/mission) under conditions defined below, if **Apollo is enabled** and **"Allow Server Reset" is enabled**.
- Add a setting "Allow Server Reset" (default enabled) which could be turned off to force keep the same data. While this is disabled, map/mission data will also not be saved.

Apollo follows the following logic:
```
if players and vehicles disabled
    -> [no reset]
else
    (get saved map/mission)

    if mission starts with "tac_ca_"
        cut mission name to "tac_ca_CampaignName"

    if map and mission didn't change
        -> [no reset]
    else
        if players enabled
            -> [reset player positions]
        if vehicles enabled
            -> [delete saved vehicles]

    (save current map/mission)
```

_Theoretically this is implemented so we can keep track of multiple servers, but this is not really used as nothing else supports per-server tracking._

**Requires Apollo update (`auto-reset` branch)!**