### PR TITLE
Apollo - Reselect weapon and cleanup unused variables

### DIFF
--- a/addons/apollo/functions/fnc_playerLoadClient.sqf
+++ b/addons/apollo/functions/fnc_playerLoadClient.sqf
@@ -40,7 +40,11 @@ if (!isNil "_result") then {
     _player setUnitLoadout _loadout;
     _player setDamage 0;
 
-    _player selectWeapon _selectedWeapon;
+    if (_selectedWeapon != "") then {
+        _player selectWeapon _selectedWeapon;
+    } else {
+        [_player] call ACEFUNC(weaponselect,putWeaponAway);
+    };
 
     // Goggles bandaid (#283 - vanilla bug) - setUnitLoadout does not properly set goggles (like dragging in inventory would)
     private _goggles = goggles _player;

--- a/addons/apollo/functions/fnc_playerLoadClient.sqf
+++ b/addons/apollo/functions/fnc_playerLoadClient.sqf
@@ -29,7 +29,7 @@ if (getPlayerUID _player == "_SP_PLAYER_") exitWith {false};
 private _result = ["loadPlayer", [getPlayerUID _player, GVAR(isDebug)]] call FUNC(callExt);
 
 if (!isNil "_result") then {
-    _result params [["_dir", -1], ["_posASL", []], ["_loadout", []]];
+    _result params [["_dir", -1], ["_posASL", []], ["_loadout", []], ["_selectedWeapon", ""]];
 
     if (_dir != -1) then {
         _player setDir _dir;
@@ -39,6 +39,8 @@ if (!isNil "_result") then {
     };
     _player setUnitLoadout _loadout;
     _player setDamage 0;
+
+    _player selectWeapon _selectedWeapon;
 
     // Goggles bandaid (#283 - vanilla bug) - setUnitLoadout does not properly set goggles (like dragging in inventory would)
     private _goggles = goggles _player;

--- a/addons/apollo/functions/fnc_playerSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_playerSingletonSave.sqf
@@ -38,14 +38,12 @@ if (_player call ACEFUNC(hearing,hasEarPlugsIn) && {!((_loadout select 3) isEqua
 };
 
 // Other
-private _inVehicle = (vehicle _player) != _player;
-private _alive = alive _player;
 private _selectedWeapon = currentWeapon _player;
 
 // Variables TODO
 private _playerVariables = [];
 
-private _serverReply = ["storeInfantry", _type, _uid, _name, _playerPos, _playerDir, _loadout, _inVehicle, _alive, _selectedWeapon, _playerVariables] call FUNC(invokeJavaMethod);
+private _serverReply = ["storeInfantry", _type, _uid, _name, _playerPos, _playerDir, _loadout, _selectedWeapon, _playerVariables] call FUNC(invokeJavaMethod);
 
 TRACE_2("Singleton Save",_type,_serverReply);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Remove sending `inVehicle` and `alive` to backend - have been removed from database a while ago.
- Select last selected weapon on player load.

**Requires Apollo (`cleanup` branch) and Athena (`reselect-weapon`) updates!**