### PR TITLE
Apollo - Fix trying to save player with invalid UID

### DIFF
--- a/addons/apollo/functions/fnc_playerSingletonSave.sqf
+++ b/addons/apollo/functions/fnc_playerSingletonSave.sqf
@@ -20,6 +20,10 @@
 
 params ["_player", "_uid", "_name", "_type"];
 
+if (_uid == "") exitWith {
+    ERROR_1("Player not saved - UID (%1) undefined!",getPlayerUID _player);
+};
+
 // Base
 private _playerPos = getPosASL _player;
 private _playerDir = getDir _player;


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Might happen on mission switch, where HandleDisconnect seems to run too late and no UIDs can be retrieved anymore.

Added a check in Apollo as well for double safety.