### PR TITLE
Mission - Handle invalid groups gracefully

### DIFF
--- a/addons/mission/functions/fnc_reinforcements.sqf
+++ b/addons/mission/functions/fnc_reinforcements.sqf
@@ -25,7 +25,7 @@ params [["_group", grpNull], "_state", ["_distance", 0], ["_moveToPlayer", false
 
 if (!isServer) exitWith {};
 if (isNull _group) exitWith {
-    WARNING("One of the groups provided does not exist.");
+    WARNING("Group does not exist.");
 };
 
 private _groupLeader = leader _group;

--- a/addons/mission/functions/fnc_reinforcements.sqf
+++ b/addons/mission/functions/fnc_reinforcements.sqf
@@ -28,8 +28,9 @@ if (isNull _group) exitWith {
     WARNING("One of the groups provided does not exist.");
 };
 
+private _groupLeader = leader _group;
 private _playerList = [] call CBA_fnc_players;
-private _anyClose = _playerList select {leader _group distance _x < _distance};
+private _anyClose = _playerList select {_groupLeader distance _x < _distance};
 
 if (_anyClose isEqualTo [] || CBA_MissionTime == 0) then {
     {

--- a/addons/mission/functions/fnc_reinforcements.sqf
+++ b/addons/mission/functions/fnc_reinforcements.sqf
@@ -5,7 +5,7 @@
  * Call from initServer.sqf
  *
  * Arguments:
- * 0: Group <GROUP>
+ * 0: Group <GROUP> (default: grpNull)
  * 1: Disable <BOOL>
  * 2: Distance <NUMBER> (default: 0)
  * 3: Move to Nearest Player <BOOL> (default: false)
@@ -21,13 +21,15 @@
  * [Test_Group_1, false, 0, true, 2000] call MFUNC(reinforcements)
  */
 
-params ["_group", "_state", ["_distance", 0], ["_moveToPlayer", false], ["_searchDistance", 1000]];
+params [["_group", grpNull], "_state", ["_distance", 0], ["_moveToPlayer", false], ["_searchDistance", 1000]];
 
 if (!isServer) exitWith {};
+if (isNull _group) exitWith {
+    WARNING("One of the groups provided does not exist.");
+};
 
-private _groupLeader = leader _group;
 private _playerList = [] call CBA_fnc_players;
-private _anyClose = _playerList select {_groupLeader distance _x < _distance};
+private _anyClose = _playerList select {leader _group distance _x < _distance};
 
 if (_anyClose isEqualTo [] || CBA_MissionTime == 0) then {
     {

--- a/addons/mission/functions/fnc_reinforcements.sqf
+++ b/addons/mission/functions/fnc_reinforcements.sqf
@@ -5,7 +5,7 @@
  * Call from initServer.sqf
  *
  * Arguments:
- * 0: Group <GROUP> (default: grpNull)
+ * 0: Group <GROUP>
  * 1: Disable <BOOL>
  * 2: Distance <NUMBER> (default: 0)
  * 3: Move to Nearest Player <BOOL> (default: false)


### PR DESCRIPTION
**When merged this pull request will:**
- If a non-existing group is passed RPT will be flooded with:
```
private _playerList = [] >
17:01:32   Error leader: Type Array, expected Object,Group,Team member
17:01:32 File x\tac\addons\mission\functions\fnc_reinforcements.sqf..., line 28
17:01:32 Error in expression <r) exitWith {};
private _groupLeader = leader _group;
private _playerList = [] >
17:01:32   Error position: <leader _group;
```

Instead, group is now default `grpNull` and will exit with a warning for it.