### PR TITLE
Mission - Add Mark Buildings Function

### DIFF
--- a/addons/mission/XEH_PREP.hpp
+++ b/addons/mission/XEH_PREP.hpp
@@ -22,6 +22,7 @@ PREP(enableAI);
 PREP(forceShooting);
 PREP(groundFog);
 PREP(jam);
+PREP(markBuildings);
 PREP(mortarStrike);
 PREP(ping);
 PREP(reaction);

--- a/addons/mission/functions/fnc_markBuildings.sqf
+++ b/addons/mission/functions/fnc_markBuildings.sqf
@@ -9,7 +9,7 @@
  *
  * Arguments:
  * 0: Objects <ARRAY>
- * 1: Filter <BOOL> (default: true)
+ * 1: Filter to only buildings <BOOL> (default: true)
  *
  * Return Value:
  * None
@@ -21,7 +21,7 @@
 
 params ["_objectArray", ["_filter", true]];
 
-if (count _objectArray == 0) exitWith {
+if (_objectArray isEqualTo []) exitWith {
     WARNING("Object Array is empty");
 };
 
@@ -31,12 +31,12 @@ if (_filter) then {
 };
 
 {
-    private _bb = boundingBoxReal _x params ["_posRelative1", "_posRelative2"];
+    (boundingBoxReal _x) params ["_posRelative1", "_posRelative2"];
     private _width = abs (_posRelative2 select 0) - (_posRelative1 select 0);
     private _height = abs (_posRelative2 select 1) - (_posRelative1 select 1);
 
-    // Marker name has to be unique.
-    private _namePos = position _x params ["_xPos", "_yPos", "_zPos"];
+    // Marker name has to be unique
+    (position _x) params ["_xPos", "_yPos", "_zPos"];
     private _markerName = format ["%1_%2%3%4", QUOTE(ADDON), _xPos, _yPos, _zPos];
     private _marker = createMarkerLocal [_markerName, getPos _x];
     _marker setMarkerBrushLocal "SolidFull";

--- a/addons/mission/functions/fnc_markBuildings.sqf
+++ b/addons/mission/functions/fnc_markBuildings.sqf
@@ -1,0 +1,47 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Mike
+ * Creates map markers for building outlines with an optional filter for only objects that inherit from buildings.
+ * Function should not be ran at any point after mission start.
+ * This is mainly designed around houses and custom structures being marked on the map, if using a layer ensure only buildings or walls are inside it.
+ *
+ * Call from initServer.sqf on mission start.
+ *
+ * Arguments:
+ * 0: Objects <ARRAY>
+ * 1: Filter <BOOL> (default: true)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [[MyObject, MyObject2]] call MFUNC(markBuildings);
+ * [(getMissionLayerEntities "Test Layer" select 0)] call MFUNC(markBuildings);
+*/
+
+params ["_objectArray", ["_filter", true]];
+
+if (count _objectArray == 0) exitWith {
+    WARNING("Object Array is empty");
+};
+
+// Filter doesn't catch everything, Arma has so many weird objects inheriting from Building, House_F etc.
+if (_filter) then {
+    _objectArray = _objectArray select {_x isKindOf "Building"};
+};
+
+{
+    private _bb = boundingBoxReal _x params ["_posRelative1", "_posRelative2"];
+    private _width = abs (_posRelative2 select 0) - (_posRelative1 select 0);
+    private _height = abs (_posRelative2 select 1) - (_posRelative1 select 1);
+
+    // Marker name has to be unique.
+    private _namePos = position _x params ["_xPos", "_yPos", "_zPos"];
+    private _markerName = format ["%1%2%3", _xPos, _yPos, _zPos];
+    private _marker = createMarkerLocal [_markerName, getPos _x];
+    _marker setMarkerBrushLocal "SolidFull";
+    _marker setMarkerColorLocal "ColorGrey";
+    _marker setMarkerDirLocal (getDir _x);
+    _marker setMarkerSizeLocal [_width / 2, _height / 2];
+    _marker setMarkerShape "RECTANGLE";
+} forEach _objectArray;

--- a/addons/mission/functions/fnc_markBuildings.sqf
+++ b/addons/mission/functions/fnc_markBuildings.sqf
@@ -37,7 +37,7 @@ if (_filter) then {
 
     // Marker name has to be unique.
     private _namePos = position _x params ["_xPos", "_yPos", "_zPos"];
-    private _markerName = format ["%1%2%3", _xPos, _yPos, _zPos];
+    private _markerName = format ["%1_%2%3%4", QUOTE(ADDON), _xPos, _yPos, _zPos];
     private _marker = createMarkerLocal [_markerName, getPos _x];
     _marker setMarkerBrushLocal "SolidFull";
     _marker setMarkerColorLocal "ColorGrey";


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a function to mark buildings the same way the map objects are done. (See image on VR)
- It's not exactly fast depending on how many objects are in the array, but wouldn't be noticeable on mission start.

![Untitled](https://github.com/Theseus-Aegis/Mods/assets/29175040/8804240a-b14f-41dd-b4d6-4ba9525f2d0a)

Marker name has to be unique, only thing I could think of that makes it so is using the object position. Examples:
```
"2293.223775.22-4.76837e-007"
"2329.533795.150"
"2373.953806.670"
"2330.523794.51-0.00336075"
"2356.343912.850"
"2343.283912.930"
"2330.373912.780"
"2317.313912.870"
"2304.33912.80"
```