### PR TITLE
Cleanup spaces in config macros

### DIFF
--- a/addons/armory/Dialog.hpp
+++ b/addons/armory/Dialog.hpp
@@ -1,10 +1,16 @@
 // Size definitions
-#define SIZEX ((safeZoneW / safeZoneH) min 1.2) // Grid width (from aspect ratio, 1.2 clamp for the largest possible size)
-#define SIZEY (SIZEX / 1.2) // Grid height (from width)
-#define W_PART(num) (num * (SIZEX / 40)) // Split grid into 40 columns
-#define H_PART(num) (num * (SIZEY / 25)) // Split grid into 25 rows
-#define X_PART(num) (W_PART(num) + (safeZoneX + (safeZoneW - SIZEX) / 2)) // Translate by columns and find left of grid
-#define Y_PART(num) (H_PART(num) + (safeZoneY + (safeZoneH - SIZEY) / 2)) // Translate by rows and find top of grid
+// Grid width (from aspect ratio, 1.2 clamp for the largest possible size)
+#define SIZEX ((safeZoneW / safeZoneH) min 1.2)
+// Grid height (from width)
+#define SIZEY (SIZEX / 1.2)
+// Split grid into 40 columns
+#define W_PART(num) (num * (SIZEX / 40))
+// Split grid into 25 rows
+#define H_PART(num) (num * (SIZEY / 25))
+// Translate by columns and find left of grid
+#define X_PART(num) (W_PART(num) + (safeZoneX + (safeZoneW - SIZEX) / 2))
+// Translate by rows and find top of grid
+#define Y_PART(num) (H_PART(num) + (safeZoneY + (safeZoneH - SIZEY) / 2))
 
 #define PIC_X X_PART(11.15)
 #define PIC_Y Y_PART(2.8)

--- a/addons/noactions/CfgActions.hpp
+++ b/addons/noactions/CfgActions.hpp
@@ -1,7 +1,7 @@
 #define NO_ACTION_CLASS(NAME, PARENT, DEFAULT) \
 class NAME: PARENT { \
     show = QUOTE(call compile getText (configFile >> 'CfgActions' >> 'NAME' >> 'GVAR(setting)')); \
-    GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)', DEFAULT)]); \
+    GVAR(setting) = QUOTE(profileNamespace getVariable [ARR_2('GVAR(NAME)',DEFAULT)]); \
 }
 
 class CfgActions {

--- a/addons/ratelmarker/CfgVehicles.hpp
+++ b/addons/ratelmarker/CfgVehicles.hpp
@@ -4,7 +4,7 @@
         class GVAR(RatelMarker) { \
             displayName = CSTRING(DisplayName); \
             condition = QUOTE(_this call FUNC(canUseMarkerMenu)); \
-            statement = QUOTE([ARR_2({call FUNC(createMarkerMenu)}, [])] call CBA_fnc_execNextFrame); \
+            statement = QUOTE([ARR_2({call FUNC(createMarkerMenu)},[])] call CBA_fnc_execNextFrame); \
             showDisabled = 0; \
             priority = 0; \
             icon = QPATHTOF(UI\ratelMarker_ca.paa); \

--- a/addons/servers/CfgMainMenuSpotlight.hpp
+++ b/addons/servers/CfgMainMenuSpotlight.hpp
@@ -2,14 +2,14 @@ class CfgMainMenuSpotlight {
     class GVAR(joinContracts) {
         text = CSTRING(contractsText);
         picture = QPATHTOF(ui\spotlight_contracts.paa);
-        action = QUOTE([ARR_2('138.201.56.116', 2302)] call (uiNamespace getVariable QQFUNC(joinServer)));
+        action = QUOTE([ARR_2('138.201.56.116',2302)] call (uiNamespace getVariable QQFUNC(joinServer)));
         actionText = CSTRING(contractsActionText);
         condition = "true";
     };
     class GVAR(joinTraining) {
         text = CSTRING(trainingText);
         picture = QPATHTOF(ui\spotlight_olympus.paa);
-        action = QUOTE([ARR_2('138.201.56.116', 2502)] call (uiNamespace getVariable QQFUNC(joinServer)));
+        action = QUOTE([ARR_2('138.201.56.116',2502)] call (uiNamespace getVariable QQFUNC(joinServer)));
         actionText = CSTRING(trainingActionText);
         condition = "true";
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Cleanup `[PW3] Warning: padding a macro argument` (HEMTT warning)