### PR TITLE
Mission - Rework Mortar Strike

### DIFF
--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -1,73 +1,81 @@
 #include "..\script_component.hpp"
+
 /*
  * Author: Mike, Jonpas
- * Orders mortars to fire on an area.
- * If amount fired is 0 the amount is randomly selected between 1-8
- * Markers must be either Area Markers (Ellipse or Rectangle)
- * Marker array can be set in init.sqf (See Example 2)
- * Marker array is randomly selected but all rounds fire on the same marker.
- * Ammo types are listed as HE (0), Smoke (1), Ilumination (2)
- * Barrage will have mortars select a new target for every round fired.
- * 1 Barrage will fire all shells at 1 target.
- * Using this script requires "force ace_mk6mortar_useAmmoHandling = false;" in cba_settings.sqf
- * This function also covers the use of CUP D30 Artillery.
+ * Orders mortars to fire on an area. Each round will be fired at a different point on a random marker provided.
+ * If amount is 0 then it will choose randomly between 1-8.
+ * Ammo types are: HE (0), Smoke (1), Illumination (2)
+ * This function also covers the CUP D30 Artillery.
+ *
+ * Call on the server.
  *
  * Arguments:
  * 0: Mortar <OBJECT>
  * 1: Marker Array <ARRAY>
- * 2: Amount <NUMBER>
+ * 2: Rounds to fire <NUMBER>
  * 3: Ammo Type <NUMBER>
- * 4: Barrages <NUMBER>
  *
  * Return Value:
- * None
+ * [ETA, Amount] <ARRAY>
  *
  * Examples:
- * [Mortar1, ["Marker1", "Marker2"], 0, 0, 2] call MFUNC(mortarStrike)
- * [Mortar1, tac_MarkerArray, 0, 0, 1] call MFUNC(mortarStrike)
+ * [My_Mortar, ["My_Marker", "My_Marker_1"], 5, 0] call MFUNC(mortarStrike);
+ * [My_Mortar, GVAR(markerArray)] call MFUNC(mortarStrike);
  */
 
-params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0], ["_barrages", 1]];
+params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0]];
 
-// Default types and delay are designed for the MK6 Mortar.
+if (!isServer) exitWith {};
+
+// HC blacklist
+private _gunner = gunner _mortar;
+_gunner setVariable ["acex_headless_blacklist", true, true];
+
+// MK6 Mortar
 private _ammoTypes = ["8Rnd_82mm_Mo_shells", "8Rnd_82mm_Mo_Smoke_white", "8Rnd_82mm_Mo_Flare_white"];
-private _delay = 2;
+private _delay = 2.5;
 
-// D30 Artillery types
+// D30 Artillery
 if (_mortar isKindOf "CUP_D30_base") then {
     _ammoTypes = ["CUP_30Rnd_122mmHE_D30_M", "CUP_30Rnd_122mmSMOKE_D30_M", "CUP_30Rnd_122mmILLUM_D30_M"];
     _delay = 5;
 };
 
 private _ammo = _ammoTypes select _ammoType;
+private _eta = 0;
 
 // Debug
-//diag_log [_mortar, _randomPosition, _ammo, _amount];
+if (_amount == 0) then {
+    _amount = floor (random 8 + 1);
+};
 
+// Disable relevant ace setting
 if (ace_mk6mortar_useAmmoHandling) exitWith {
     WARNING("ACE Ammo Handling setting is enabled.");
 };
 
-if (_barrages < 1) exitWith {
-    WARNING_1("Barrages (%1) cannot be less than 1.",_barrages);
+// Error on marker being incorrect type
+private _invalidMarker = _markersArray findIf {!(markerShape _x in ["RECTANGLE", "ELLIPSE"])};
+if (_invalidMarker != -1) exitWith {
+    private _failedMarker = _markersArray select _invalidMarker;
+    ERROR_MSG_1("Marker: %1 is not an area marker (rectangle or ellipse)",_failedMarker);
 };
 
+// Warn on first out of range marker found
 private _outOfRange = _markersArray findIf {!((getMarkerPos _x) inRangeOfArtillery [[_mortar], _ammo])};
 if (_outOfRange != -1) exitWith {
     WARNING_1("Marker Index: %1 is out of range of Artillery",_outOfRange);
 };
 
-for "_i" from 0 to _barrages - 1 do {
-    private _randomMarker = selectRandom _markersArray;
-    private _randomPosition = [_randomMarker, true] call CBA_fnc_randPosArea;
-
-    if (_amount == 0) then {
-        _amount = random 8 + 1;
-    };
-
+for "_i" from 0 to _amount - 1 do {
+    private _marker = selectRandom _markersArray;
+    private _position = [_marker, true] call CBA_fnc_randPosArea;
+    _eta = floor (_mortar getArtilleryETA [_position, _ammo]);
     [{
-        params ["_mortar", "_randomPosition", "_ammo", "_amount"];
-        _mortar doArtilleryFire [_randomPosition, _ammo, _amount];
+        params ["_mortar", "_position", "_ammo", "_gunner"];
+        _gunner doArtilleryFire [_position, _ammo, 1];
         _mortar setVehicleAmmo 1;
-    }, [_mortar, _randomPosition, _ammo, _amount], _i * _delay] call CBA_fnc_waitAndExecute;
+    }, [_mortar, _position, _ammo, _gunner], _i * _delay] call CBA_fnc_waitAndExecute;
 };
+
+[_eta, _amount]

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -1,5 +1,4 @@
 #include "..\script_component.hpp"
-
 /*
  * Author: Mike, Jonpas
  * Orders mortars to fire on an area. Each round will be fired at a different point on a random marker provided.

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -15,7 +15,8 @@
  * 3: Ammo Type <NUMBER>
  *
  * Return Value:
- * [ETA, Amount] <ARRAY>
+ * 0: ETA (seconds) <NUMBER>
+ * 1: Amount <NUMBER>
  *
  * Examples:
  * [My_Mortar, ["My_Marker", "My_Marker_1"], 5, 0] call MFUNC(mortarStrike)

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -26,9 +26,11 @@ params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0]];
 
 if (!isServer) exitWith {};
 
-// HC blacklist
 private _gunner = gunner _mortar;
-_gunner setVariable ["acex_headless_blacklist", true, true];
+
+if !(_gunner getVariable ["acex_headless_blacklist", false]) exitWith {
+    ERROR_MSG("Function requires HC blacklist to work.");
+};
 
 // MK6 Mortar
 private _ammoTypes = ["8Rnd_82mm_Mo_shells", "8Rnd_82mm_Mo_Smoke_white", "8Rnd_82mm_Mo_Flare_white"];

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -18,8 +18,8 @@
  * [ETA, Amount] <ARRAY>
  *
  * Examples:
- * [My_Mortar, ["My_Marker", "My_Marker_1"], 5, 0] call MFUNC(mortarStrike);
- * [My_Mortar, GVAR(markerArray)] call MFUNC(mortarStrike);
+ * [My_Mortar, ["My_Marker", "My_Marker_1"], 5, 0] call MFUNC(mortarStrike)
+ * [My_Mortar, GVAR(markerArray)] call MFUNC(mortarStrike)
  */
 
 params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0]];


### PR DESCRIPTION
**When merged this pull request will:**
- Lowers the complexity of the function, removes the barrages part entirely.
- Still handles MK6 Mortar & D30 as before.
- random amount is now whole number.
- Handles invalid markers with error. (has to be done before inRange otherwise that will be the error, easier to debug this way.)
- Instead of firing an amount every X barrage, now just fires 1 round until it reaches required amount.
- Returns the ETA of the round and the amount fired.
- Now uses the correct syntax for `doArtilleryFire`

**I'm being nice and even writing out a reason for this one before I forget.**
Something was off with amount & barrages, not entirely sure what but you wouldn't get the amount fired you wanted. Plus it just added to the confusion of this entire function.
I had a usecase for the ETA and amount fired which it didn't provide.
Overall, it's simpler now at the cost of broken BWC which is just 1 parameter.

It works!