### PR TITLE
Add Headless automatic move with players

### DIFF
--- a/addons/headless/$PBOPREFIX$
+++ b/addons/headless/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\headless

--- a/addons/headless/CfgEventHandlers.hpp
+++ b/addons/headless/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/headless/XEH_PREP.hpp
+++ b/addons/headless/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(moveHeadless);

--- a/addons/headless/XEH_preInit.sqf
+++ b/addons/headless/XEH_preInit.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+#include "initSettings.inc.sqf"
+
+ADDON = true;

--- a/addons/headless/XEH_preInit.sqf
+++ b/addons/headless/XEH_preInit.sqf
@@ -6,6 +6,10 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+if (isServer) then {
+    GVAR(moveHeadlessThread) = false;
+};
+
 #include "initSettings.inc.sqf"
 
 ADDON = true;

--- a/addons/headless/XEH_preStart.sqf
+++ b/addons/headless/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/headless/config.cpp
+++ b/addons/headless/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main"};
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(main,Author);
+        authors[] = {"Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -22,11 +22,12 @@
         [_handle] call CBA_fnc_removePerFrameHandler;
     };
 
-    private _players = [true] call EFUNC(mission,players);
+    private _playersAll = (call CBA_fnc_players) select {!(_x getVariable [QACEGVAR(spectator,isSet), false])};
+    private _players = _playersAll select {isTouchingGround (vehicle _x)};
 
-    // If ground players are minority (<20%), include air as well
-    if (count _players < 0.2 * count (call CBA_fnc_players)) then {
-        _players = [] call EFUNC(mission,players);
+    // If ground players are minority (<20%), include air/water as well
+    if (count _players < 0.2 * (count _playersAll)) then {
+        _players = _playersAll;
     };
 
     if (_players isEqualTo []) exitWith {};

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -15,8 +15,6 @@
  * Public: No
  */
 
-params ["", "_handle"];
-
 if (!GVAR(moveHeadless)) exitWith {
     GVAR(moveHeadlessThread) = false;
 };

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -25,7 +25,12 @@
     private _players = [true] call EFUNC(mission,players);
     if (_players isEqualTo []) exitWith {};
 
-    // Pick a non-pilot to move to
+    // If ground players are minority (<10%), include air as well
+    if (count _players < 0.1 * (call CBA_fnc_players)) then {
+        _players = [] call EFUNC(mission,players);
+    };
+
+    // Pick a player to move to
     private _position = ASLtoAGL (getPosASL (selectRandom _players));
     _position set [2, 0];
 
@@ -35,5 +40,5 @@
         };
 
         _x setPosASL (AGLToASL _position);
-    } forEach entities "HeadlessClient_F";
+    } forEach (entities "HeadlessClient_F");
 }, 60] call CBA_fnc_addPerFrameHandler;

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -16,24 +16,43 @@
  */
 
 [{
-    params ["_args", "_handle"];
+    params ["", "_handle"];
 
     if (!GVAR(headlessMove)) exitWith {
         [_handle] call CBA_fnc_removePerFrameHandler;
     };
 
     private _players = [true] call EFUNC(mission,players);
-    if (_players isEqualTo []) exitWith {};
 
-    // If ground players are minority (<10%), include air as well
-    if (count _players < 0.1 * (call CBA_fnc_players)) then {
+    // If ground players are minority (<20%), include air as well
+    if (count _players < 0.2 * count (call CBA_fnc_players)) then {
         _players = [] call EFUNC(mission,players);
     };
 
-    // Pick a player to move to
-    private _position = ASLtoAGL (getPosASL (selectRandom _players));
-    _position set [2, 0];
+    if (_players isEqualTo []) exitWith {};
 
+    // Find average position of all players, removing 10% bottom and 10% top outliers
+    private _positions = _players apply {getPosASL _x};
+    private _positionsX = _positions apply {_x select 0};
+    private _positionsY = _positions apply {_x select 1};
+    _positionsX sort true;
+    _positionsY sort true;
+
+    private _positionsCount = count _positions;
+    _positionsX = _positionsX select [0.1 * _positionsCount, 0.8 * _positionsCount];
+    _positionsY = _positionsY select [0.1 * _positionsCount, 0.8 * _positionsCount];
+    _positionsCount = count _positionsX;
+
+    private _positionX = 0;
+    private _positionY = 0;
+    { _positionX = _positionX + _x } forEach _positionsX;
+    { _positionY = _positionY + _x } forEach _positionsY;
+    _positionX = _positionX / _positionsCount;
+    _positionY = _positionY / _positionsCount;
+
+    private _position = [_positionX, _positionY, 0]; // always at ground level
+
+    // Move
     {
         if (!isObjectHidden _x) then {
             _x hideObjectGlobal true;

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -15,50 +15,50 @@
  * Public: No
  */
 
-[{
-    params ["", "_handle"];
+params ["", "_handle"];
 
-    if (!GVAR(headlessMove)) exitWith {
-        [_handle] call CBA_fnc_removePerFrameHandler;
+if (!GVAR(moveHeadless)) exitWith {
+    GVAR(moveHeadlessThread) = false;
+};
+
+private _playersAll = (call CBA_fnc_players) select {!(_x getVariable [QACEGVAR(spectator,isSet), false])};
+private _players = _playersAll select {isTouchingGround (vehicle _x)};
+
+// If ground players are minority (<20%), include air/water as well
+if (count _players < 0.2 * (count _playersAll)) then {
+    _players = _playersAll;
+};
+
+if (_players isEqualTo []) exitWith {};
+
+// Find average position of all players, removing 10% bottom and 10% top outliers
+private _positions = _players apply {getPosASL _x};
+private _positionsX = _positions apply {_x select 0};
+private _positionsY = _positions apply {_x select 1};
+_positionsX sort true;
+_positionsY sort true;
+
+private _positionsCount = count _positions;
+_positionsX = _positionsX select [0.1 * _positionsCount, 0.8 * _positionsCount];
+_positionsY = _positionsY select [0.1 * _positionsCount, 0.8 * _positionsCount];
+_positionsCount = count _positionsX;
+
+private _positionX = 0;
+private _positionY = 0;
+{ _positionX = _positionX + _x } forEach _positionsX;
+{ _positionY = _positionY + _x } forEach _positionsY;
+_positionX = _positionX / _positionsCount;
+_positionY = _positionY / _positionsCount;
+
+private _position = [_positionX, _positionY, 0]; // always at ground level
+
+// Move
+{
+    if (!isObjectHidden _x) then {
+        _x hideObjectGlobal true;
     };
 
-    private _playersAll = (call CBA_fnc_players) select {!(_x getVariable [QACEGVAR(spectator,isSet), false])};
-    private _players = _playersAll select {isTouchingGround (vehicle _x)};
+    _x setPosASL (AGLToASL _position);
+} forEach (entities "HeadlessClient_F");
 
-    // If ground players are minority (<20%), include air/water as well
-    if (count _players < 0.2 * (count _playersAll)) then {
-        _players = _playersAll;
-    };
-
-    if (_players isEqualTo []) exitWith {};
-
-    // Find average position of all players, removing 10% bottom and 10% top outliers
-    private _positions = _players apply {getPosASL _x};
-    private _positionsX = _positions apply {_x select 0};
-    private _positionsY = _positions apply {_x select 1};
-    _positionsX sort true;
-    _positionsY sort true;
-
-    private _positionsCount = count _positions;
-    _positionsX = _positionsX select [0.1 * _positionsCount, 0.8 * _positionsCount];
-    _positionsY = _positionsY select [0.1 * _positionsCount, 0.8 * _positionsCount];
-    _positionsCount = count _positionsX;
-
-    private _positionX = 0;
-    private _positionY = 0;
-    { _positionX = _positionX + _x } forEach _positionsX;
-    { _positionY = _positionY + _x } forEach _positionsY;
-    _positionX = _positionX / _positionsCount;
-    _positionY = _positionY / _positionsCount;
-
-    private _position = [_positionX, _positionY, 0]; // always at ground level
-
-    // Move
-    {
-        if (!isObjectHidden _x) then {
-            _x hideObjectGlobal true;
-        };
-
-        _x setPosASL (AGLToASL _position);
-    } forEach (entities "HeadlessClient_F");
-}, 60] call CBA_fnc_addPerFrameHandler;
+[FUNC(moveHeadless), [], 60] call CBA_fnc_waitAndExecute;

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -1,0 +1,36 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Mike
+ * Handles automatically moving headless clients to randomly selected players.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call FUNC(moveHeadless)
+ *
+ * Public: No
+ */
+
+[{
+    params ["_args", "_handle"];
+
+    if (!GVAR(headlessMove)) exitWith {
+        [_handle] call CBA_fnc_removePerFrameHandler;
+    };
+
+    private _players = [true] call MFUNC(players);
+    if (_players isEqualTo []) exitWith {};
+
+    {
+        if (!isObjectHidden _x) then {
+            _x hideObjectGlobal true;
+        };
+
+        // Pick a non-pilot to move to
+        _x setPos (getPos selectRandom _players);
+    } forEach entities "HeadlessClient_F";
+}, 60] call CBA_fnc_addPerFrameHandler;

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-if (!GVAR(moveHeadless)) exitWith {
+if (!GVAR(moveHeadless) || !acex_headless_enabled) exitWith {
     GVAR(moveHeadlessThread) = false;
 };
 
@@ -57,6 +57,6 @@ private _position = [_positionX, _positionY, 0]; // always at ground level
     };
 
     _x setPosASL (AGLToASL _position);
-} forEach (entities "HeadlessClient_F");
+} forEach ACEGVAR(headless,headlessClients);
 
 [FUNC(moveHeadless), [], 60] call CBA_fnc_waitAndExecute;

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -22,7 +22,7 @@
         [_handle] call CBA_fnc_removePerFrameHandler;
     };
 
-    private _players = [true] call MFUNC(players);
+    private _players = [true] call EFUNC(mission,players);
     if (_players isEqualTo []) exitWith {};
 
     {

--- a/addons/headless/functions/fnc_moveHeadless.sqf
+++ b/addons/headless/functions/fnc_moveHeadless.sqf
@@ -25,12 +25,15 @@
     private _players = [true] call EFUNC(mission,players);
     if (_players isEqualTo []) exitWith {};
 
+    // Pick a non-pilot to move to
+    private _position = ASLtoAGL (getPosASL (selectRandom _players));
+    _position set [2, 0];
+
     {
         if (!isObjectHidden _x) then {
             _x hideObjectGlobal true;
         };
 
-        // Pick a non-pilot to move to
-        _x setPos (getPos selectRandom _players);
+        _x setPosASL (AGLToASL _position);
     } forEach entities "HeadlessClient_F";
 }, 60] call CBA_fnc_addPerFrameHandler;

--- a/addons/headless/initSettings.inc.sqf
+++ b/addons/headless/initSettings.inc.sqf
@@ -1,0 +1,14 @@
+[
+    QGVAR(headlessMove),
+    "CHECKBOX",
+    [LSTRING(headlessPosition), LSTRING(headlessPositionDesc)],
+    format ["TAC %1", localize LSTRING(DisplayName)],
+    true,
+    {
+        if (!isServer) exitWith {};
+        params ["_value"];
+        if (_value) then {
+            call FUNC(moveHeadless);
+        };
+    };
+] call CBA_fnc_addSetting;

--- a/addons/headless/initSettings.inc.sqf
+++ b/addons/headless/initSettings.inc.sqf
@@ -7,7 +7,7 @@
     {
         if (isServer) then {
             params ["_enabled"];
-            if (_enabled && {!GVAR(moveHeadlessThread)) then {
+            if (_enabled && {!GVAR(moveHeadlessThread)}) then {
                 GVAR(moveHeadlessThread) = true;
                 [FUNC(moveHeadless), [], 1] call CBA_fnc_waitAndExecute;
             };

--- a/addons/headless/initSettings.inc.sqf
+++ b/addons/headless/initSettings.inc.sqf
@@ -1,14 +1,16 @@
 [
-    QGVAR(headlessMove),
+    QGVAR(moveHeadless),
     "CHECKBOX",
-    [LSTRING(headlessPosition), LSTRING(headlessPositionDesc)],
-    format ["TAC %1", localize LSTRING(DisplayName)],
+    [LSTRING(moveHeadless), LSTRING(moveHeadlessDesc)],
+    format ["TAC %1", localize "str_a3_rscdisplaywelcome_expa_parc_list6_title"],
     true,
     {
-        if (!isServer) exitWith {};
-        params ["_value"];
-        if (_value) then {
-            call FUNC(moveHeadless);
+        if (isServer) then {
+            params ["_enabled"];
+            if (_enabled && {!GVAR(moveHeadlessThread)) then {
+                GVAR(moveHeadlessThread) = true;
+                [FUNC(moveHeadless), [], 1] call CBA_fnc_waitAndExecute;
+            };
         };
     }
 ] call CBA_fnc_addSetting;

--- a/addons/headless/initSettings.inc.sqf
+++ b/addons/headless/initSettings.inc.sqf
@@ -7,7 +7,7 @@
     {
         if (isServer) then {
             params ["_enabled"];
-            if (_enabled && {!GVAR(moveHeadlessThread)}) then {
+            if (_enabled && acex_headless_enabled && {!GVAR(moveHeadlessThread)}) then {
                 GVAR(moveHeadlessThread) = true;
                 [FUNC(moveHeadless), [], 1] call CBA_fnc_waitAndExecute;
             };

--- a/addons/headless/initSettings.inc.sqf
+++ b/addons/headless/initSettings.inc.sqf
@@ -10,5 +10,5 @@
         if (_value) then {
             call FUNC(moveHeadless);
         };
-    };
+    }
 ] call CBA_fnc_addSetting;

--- a/addons/headless/script_component.hpp
+++ b/addons/headless/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT headless
+#define COMPONENT_BEAUTIFIED Headless
+#include "\x\tac\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_HEADLESS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_HEADLESS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_HEADLESS
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"

--- a/addons/headless/stringtable.xml
+++ b/addons/headless/stringtable.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TAC">
     <Package name="Headless">
-        <Key ID="STR_TAC_Headless_DisplayName">
-            <English>Headless</English>
+        <Key ID="STR_TAC_Headless_moveHeadless">
+            <English>Move Headless</English>
         </Key>
-        <Key ID="STR_TAC_Headless_headlessPosition">
-            <English>Update Headless Position</English>
-        </Key>
-        <Key ID="STR_TAC_Headless_headlessPositionDesc">
+        <Key ID="STR_TAC_Headless_moveHeadlessDesc">
             <English>Enables automatic positioning of headless client near players.</English>
         </Key>
     </Package>

--- a/addons/headless/stringtable.xml
+++ b/addons/headless/stringtable.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="TAC">
+    <Package name="Headless">
+        <Key ID="STR_TAC_Headless_DisplayName">
+            <English>Headless</English>
+        </Key>
+        <Key ID="STR_TAC_Headless_headlessPosition">
+            <English>Update Headless Position</English>
+        </Key>
+        <Key ID="STR_TAC_Headless_headlessPositionDesc">
+            <English>Enables automatic positioning of headless client near players.</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/mission/functions/fnc_players.sqf
+++ b/addons/mission/functions/fnc_players.sqf
@@ -1,10 +1,11 @@
 #include "..\script_component.hpp"
 /*
  * Author: Mike
- * Wrapper of CBA_fnc_players, removing players in spectator and optionally any units in the air/water.
+ * Wrapper of CBA_fnc_players, removing players in spectator
+ * and optionally any units not touching the ground (eg. in the air/water).
  *
  * Arguments:
- * 0: Skip units in the air/water <BOOL>
+ * 0: Skip units not touching the ground <BOOL>
  *
  * Return Value:
  * Players <ARRAY>
@@ -14,11 +15,11 @@
  * [true] call MFUNC(players)
  */
 
-params [["_skipInAirWater", false]];
+params [["_skipNotGround", false]];
 
 private _players = (call CBA_fnc_players) select {!(_x getVariable [QACEGVAR(spectator,isSet), false])};
 
-if (_skipInAirWater) then {
+if (_skipNotGround) then {
     _players = _players select {isTouchingGround (vehicle _x)}; // Check vehicle, not the unit
 };
 

--- a/addons/mission/functions/fnc_players.sqf
+++ b/addons/mission/functions/fnc_players.sqf
@@ -1,10 +1,10 @@
 #include "..\script_component.hpp"
 /*
  * Author: Mike
- * Wrapper of CBA_fnc_players, removing players in spectator and optionally any units in the air.
+ * Wrapper of CBA_fnc_players, removing players in spectator and optionally any units in the air/water.
  *
  * Arguments:
- * 0: Skip units in the air <BOOL>
+ * 0: Skip units in the air/water <BOOL>
  *
  * Return Value:
  * Players <ARRAY>
@@ -14,11 +14,11 @@
  * [true] call MFUNC(players)
  */
 
-params [["_skipInAir", false]];
+params [["_skipInAirWater", false]];
 
 private _players = (call CBA_fnc_players) select {!(_x getVariable [QACEGVAR(spectator,isSet), false])};
 
-if (_skipInAir) then {
+if (_skipInAirWater) then {
     _players = _players select {isTouchingGround (vehicle _x)}; // Check vehicle, not the unit
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Adds new headless component.
- Setting for disabling function.
- HC is hidden to prevent clipping issues (Still functions as normal)
- Runs a loop every 60s to select a random player not in spectator or flying and sets the HC position to them.
- Can be disabled/re-enabled in mission.
