### PR TITLE
Mission - Fix mortar firing delay

### DIFF
--- a/addons/mission/XEH_postInit.sqf
+++ b/addons/mission/XEH_postInit.sqf
@@ -17,6 +17,7 @@ if (isServer) then {
 [QGVAR(enableAI), {(_this select 0) enableAI (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(say3D), {(_this select 0) say3D (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(setCombatMode), {(_this select 0) setCombatMode  (_this select 1)}] call CBA_fnc_addEventHandler;
+[QGVAR(setDir), {(_this select 0) setDir (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(setSpeedMode), {(_this select 0) setSpeedMode (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(setUnitPos), {(_this select 0) setUnitPos (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(setVehicleAmmo), {(_this select 0) setVehicleAmmo (_this select 1)}] call CBA_fnc_addEventHandler;

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -46,6 +46,10 @@ if (_amount == 0) then {
     _amount = floor (random 8 + 1);
 };
 
+// Force mortar to look in the general direction where it will fire, should eliminate the delay on not firing the first round.
+private _dir = _mortar getDir (getMarkerPos (_markersArray select 0));
+[QGVAR(setDir), [_mortar, _dir], _mortar] call CBA_fnc_targetEvent;
+
 // Disable relevant ace setting
 if (ace_mk6mortar_useAmmoHandling) exitWith {
     WARNING("ACE Ammo Handling setting is enabled.");

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -27,6 +27,10 @@ params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0]];
 
 if (!isServer) exitWith {};
 
+// Force mortar to look in the general direction where it will fire, should eliminate the delay on not firing the first round.
+private _dir = _mortar getDir (getMarkerPos (_markersArray select 0));
+[QGVAR(setDir), [_mortar, _dir], _mortar] call CBA_fnc_targetEvent;
+
 // MK6 Mortar
 private _ammoTypes = ["8Rnd_82mm_Mo_shells", "8Rnd_82mm_Mo_Smoke_white", "8Rnd_82mm_Mo_Flare_white"];
 private _delay = 2.5;
@@ -45,10 +49,6 @@ private _eta = 0;
 if (_amount == 0) then {
     _amount = floor (random 8 + 1);
 };
-
-// Force mortar to look in the general direction where it will fire, should eliminate the delay on not firing the first round.
-private _dir = _mortar getDir (getMarkerPos (_markersArray select 0));
-[QGVAR(setDir), [_mortar, _dir], _mortar] call CBA_fnc_targetEvent;
 
 // Disable relevant ace setting
 if (ace_mk6mortar_useAmmoHandling) exitWith {


### PR DESCRIPTION
- Currently the mortar can completely skip firing the first round because of traversal time. This should get it to look in the right direction before the `doArtilleryFire` begins giving it a much better chance of actually firing instead of skipping.

- My initial testing of this is done in a function that calls this one, it works as intended.
- Testing it by setting direction just before it fires isn't enough time, but even if the strike fails for any reason having it face the right way doesn't matter all that much.