### PR TITLE
Settings - Adjust AI Damage Threshold, Repair and Trench

### DIFF
--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -27,7 +27,6 @@ ace_interaction_disableNegativeRating = true;
 
 ace_map_defaultChannel = 1;
 
-ace_medical_AIDamageThreshold = 0.6; // (default: 1)
 ace_medical_deathChance = 0.15; // 15% (default: 100%)
 ace_medical_feedback_bloodVolumeEffectType = 0; // Force client setting (default: 0 - Screen Effects)
 ace_medical_painUnconsciousChance = 0.20; // 20% (default: 10%)
@@ -63,6 +62,8 @@ ace_repair_addSpareParts = false; // No (default: true - Yes)
 ace_repair_engineerSetting_fullRepair = 0; // Anyone (default: 2 - Advanced Engineer only)
 ace_repair_engineerSetting_Repair = 0; // Anyone (default: 1 - Engineer only)
 ace_repair_fullRepairLocation = 3; // Repair Facility or Vehicle (default: 2 - Repair Facility only)
+ace_repair_patchWheelMaximumRepair = 0.5; // Default 0.3, 50% instead of 70%
+ace_repair_timeCoefficientFullRepair = 0.25; // Default 1.50, ridiculous.
 
 ace_respawn_removeDeadBodiesDisconnected = false;
 
@@ -78,15 +79,15 @@ acex_volume_enabled = true; // Force client setting
 acex_volume_lowerInVehicles = true; // Force client setting
 
 // GRAD Trenches
-grad_trenches_functions_allowLongEnvelope = false;
-grad_trenches_functions_allowSmallEnvelope = false;
-grad_trenches_functions_allowVehicleEnvelope = false;
 grad_trenches_functions_allowCamouflage = false;
+grad_trenches_functions_allowGiantEnvelope = false;
+grad_trenches_functions_allowLongEnvelope = false;
+grad_trenches_functions_allowVehicleEnvelope = false;
 
 grad_trenches_functions_buildFatigueFactor = 0.2;
-grad_trenches_functions_shortEnvelopeDigTime = 60;
-grad_trenches_functions_bigEnvelopeDigTime = 180;
-grad_trenches_functions_giantEnvelopeDigTime = 300;
+grad_trenches_functions_shortEnvelopeDigTime = 240; // Medium Size
+grad_trenches_functions_smallEnvelopeDigTime = 120; // Smallest
+grad_trenches_functions_bigEnvelopeDigTime = 480; // Largest
 
 // OCAP
 ocap_settings_autoStart = false;

--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -62,7 +62,7 @@ ace_repair_addSpareParts = false; // No (default: true - Yes)
 ace_repair_engineerSetting_fullRepair = 0; // Anyone (default: 2 - Advanced Engineer only)
 ace_repair_engineerSetting_Repair = 0; // Anyone (default: 1 - Engineer only)
 ace_repair_fullRepairLocation = 3; // Repair Facility or Vehicle (default: 2 - Repair Facility only)
-ace_repair_patchWheelMaximumRepair = 0.5; // 50% (default: 0.3 - 30%)
+ace_repair_patchWheelMaximumRepair = 0.5; // 50% (default: 0.3 - 30%), setting defines what level of damage you can repair the wheel to
 ace_repair_timeCoefficientFullRepair = 0.25; // Default: 1.50
 
 ace_respawn_removeDeadBodiesDisconnected = false;

--- a/addons/cba_settings/cba_settings.sqf
+++ b/addons/cba_settings/cba_settings.sqf
@@ -20,7 +20,7 @@ ace_fastroping_autoAddFRIES = true;
 
 ace_finger_enabled = true;
 
-ace_hearing_autoAddEarplugsToUnits = false;
+ace_hearing_autoAddEarplugsToUnits = 0; // Disabled (default: 1 - Only units with heavy weapons)
 ace_hearing_enabledForZeusUnits = false;
 
 ace_interaction_disableNegativeRating = true;
@@ -62,8 +62,8 @@ ace_repair_addSpareParts = false; // No (default: true - Yes)
 ace_repair_engineerSetting_fullRepair = 0; // Anyone (default: 2 - Advanced Engineer only)
 ace_repair_engineerSetting_Repair = 0; // Anyone (default: 1 - Engineer only)
 ace_repair_fullRepairLocation = 3; // Repair Facility or Vehicle (default: 2 - Repair Facility only)
-ace_repair_patchWheelMaximumRepair = 0.5; // Default 0.3, 50% instead of 70%
-ace_repair_timeCoefficientFullRepair = 0.25; // Default 1.50, ridiculous.
+ace_repair_patchWheelMaximumRepair = 0.5; // 50% (default: 0.3 - 30%)
+ace_repair_timeCoefficientFullRepair = 0.25; // Default: 1.50
 
 ace_respawn_removeDeadBodiesDisconnected = false;
 
@@ -85,9 +85,9 @@ grad_trenches_functions_allowLongEnvelope = false;
 grad_trenches_functions_allowVehicleEnvelope = false;
 
 grad_trenches_functions_buildFatigueFactor = 0.2;
-grad_trenches_functions_shortEnvelopeDigTime = 240; // Medium Size
-grad_trenches_functions_smallEnvelopeDigTime = 120; // Smallest
-grad_trenches_functions_bigEnvelopeDigTime = 480; // Largest
+grad_trenches_functions_shortEnvelopeDigTime = 240; // Smallest (default: 15)
+grad_trenches_functions_smallEnvelopeDigTime = 120; // Medium (default: 30)
+grad_trenches_functions_bigEnvelopeDigTime = 480; // Largest (default: 40)
 
 // OCAP
 ocap_settings_autoStart = false;


### PR DESCRIPTION
- Reverted the 0.6 AI damage, shouldn't be necessary anymore.

**Trench Stuff:**
Me and Mick have been balancing out trenches trying to move us away from digging sandcastles everywhere we go.
- Removed the largest
- Readded the smallest
- Set the times to be 2 minutes, 4 minutes & 8 minutes, obviously scales down with amount of players helping.

**Repair Stuff:**
Coordinated with Mick & Alan
- Sets up a reasonable full repair timer, nearly 7 minutes for a vehicle at 50% is insane.
- Lowers the wheel patching from 70% to 50% otherwise spare wheels are only useful for direct replacement of a destroyed one.