### PR TITLE
MELB - Switch `animate` to `animateSource`

### DIFF
--- a/addons/melb/functions/fnc_toggleMFD.sqf
+++ b/addons/melb/functions/fnc_toggleMFD.sqf
@@ -21,24 +21,24 @@ LOG_1("toggle MFD",_vehicle);
 // Pilot
 if (ACE_player == driver _vehicle) then {
     if (_vehicle animationPhase "MFD_Pilot" > 0) then {
-        _vehicle animate ["pilotpip", 0];
-        _vehicle animate ["MFD_Pilot", 0];
+        _vehicle animateSource ["pilotpip", 0];
+        _vehicle animateSource ["MFD_Pilot", 0];
         GVAR(camera) cameraEffect ["Terminate", "BACK"];
     } else {
-        _vehicle animate ["MFD_Pilot", 1];
-        _vehicle animate ["pilotpip", 1];
+        _vehicle animateSource ["MFD_Pilot", 1];
+        _vehicle animateSource ["pilotpip", 1];
         [_vehicle] call FUNC(setupMFD);
     };
 } else {
     // Copilot
     if (ACE_player == gunner _vehicle) then {
         if (_vehicle animationPhase "MFD_CoPilot" > 0) then {
-            _vehicle animate ["copilotpip", 0];
-            _vehicle animate ["MFD_CoPilot", 0];
+            _vehicle animateSource ["copilotpip", 0];
+            _vehicle animateSource ["MFD_CoPilot", 0];
             GVAR(camera) cameraEffect ["Terminate", "BACK"];
         } else {
-            _vehicle animate ["MFD_CoPilot", 1];
-            _vehicle animate ["copilotpip", 1];
+            _vehicle animateSource ["MFD_CoPilot", 1];
+            _vehicle animateSource ["copilotpip", 1];
             [_vehicle] call FUNC(setupMFD);
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- title, `animateSource` is apparently better optimised for MP and more efficient.
