### PR TITLE
Medical - Add Unconscious Effects

### DIFF
--- a/addons/medical/XEH_PREP.hpp
+++ b/addons/medical/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(unconsciousFX);

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -54,7 +54,7 @@ if (isServer) then {
     ["ace_unconscious", {
         params ["_unit", "_state"];
 
-        if !(GVAR(unconsciousFXEnabled)) exitWith {};
+        if (GVAR(unconsciousFXChance) == 0) exitWith {};
 
         if (isPlayer _unit && _state) then {
             // Knock out sound

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -59,7 +59,7 @@ if (isServer) then {
         if (isPlayer _unit && _state) then {
             // Knock out sound
             private _knockOutNoise = selectRandom KO_NOISES;
-            [QEGVAR(mission,say3D), [_unit, _knockOutNoise]] call CBA_fnc_globalEvent;
+            [QGVAR(say3D), [_unit, _knockOutNoise]] call CBA_fnc_globalEvent;
 
             // Local PFH for periodic groaning
             [QGVAR(unconsciousFX), [], _unit] call CBA_fnc_targetEvent;
@@ -67,4 +67,5 @@ if (isServer) then {
     }] call CBA_fnc_addEventHandler;
 };
 
+[QGVAR(say3D), {(_this select 0) say3D (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(unconsciousFx), LINKFUNC(unconsciousFX)] call CBA_fnc_addEventHandler;

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -48,3 +48,23 @@
         };
     }, _unit, 1] call CBA_fnc_waitAndExecute;
 }] call CBA_fnc_addEventHandler;
+
+// Unconscious Moaning
+if (isServer) then {
+    ["ace_unconscious", {
+        params ["_unit", "_state"];
+
+        if !(GVAR(unconsciousFXEnabled)) exitWith {};
+
+        if (isPlayer _unit && _state) then {
+            // Knock out sound
+            private _knockOutNoise = selectRandom KO_NOISES;
+            [QEGVAR(mission,say3D), [_unit, _knockOutNoise]] call CBA_fnc_globalEvent;
+
+            // Local PFH for periodic groaning
+            [QGVAR(unconsciousFX), [], _unit] call CBA_fnc_targetEvent;
+        };
+    }] call CBA_fnc_addEventHandler;
+};
+
+[QGVAR(unconsciousFx), LINKFUNC(unconsciousFX)] call CBA_fnc_addEventHandler;

--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -2,6 +2,10 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
 #include "initSettings.inc.sqf"
 
 ADDON = true;

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -6,9 +6,13 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tac_main", "ace_medical_engine"};
+        requiredAddons[] = {
+            "tac_main",
+            "tac_mission",
+            "ace_medical_engine"
+        };
         author = ECSTRING(main,Author);
-        authors[] = {"Jonpas"};
+        authors[] = {"Jonpas", "Mike"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -8,7 +8,6 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "tac_main",
-            "tac_mission",
             "ace_fire",
             "ace_medical_engine",
             "ace_medical_feedback"

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -9,7 +9,9 @@ class CfgPatches {
         requiredAddons[] = {
             "tac_main",
             "tac_mission",
-            "ace_medical_engine"
+            "ace_fire",
+            "ace_medical_engine",
+            "ace_medical_feedback"
         };
         author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "Mike"};

--- a/addons/medical/functions/fnc_unconsciousFX.sqf
+++ b/addons/medical/functions/fnc_unconsciousFX.sqf
@@ -1,0 +1,38 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Mike
+ * Handles noises while unconscious
+ *
+ * Called locally per player via target event
+ *
+ * Arguments
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call tac_medical_fnc_unconsciousFX
+*/
+
+[{
+    params ["_args", "_handle"];
+    _args params [["_firstIteration", true]];
+
+    // If woken up or died end PFH.
+    if !(ace_player getVariable ["ACE_isUnconscious", false]) exitWith {
+        _handle call CBA_fnc_removePerFrameHandler;
+    };
+
+    // Don't want the groaning to happen instantly.
+    if (_firstIteration) exitWith {
+        _args set [0, false];
+    };
+
+    // 50% chance of making noises, requires a heart rate above CPR/Cardiac Arrest
+    private _heartRate = ace_player getVariable ["ace_medical_heartRate", 80];
+    if (random 1 > GVAR(unconsciousFXChance) && _heartRate > 40) then {
+        private _moan = selectRandom UNCONSCIOUS_NOISES;
+        [QEGVAR(mission,say3D), [ace_player, _moan]] call CBA_fnc_globalEvent;
+    };
+}, GVAR(unconsciousFXTimer)] call CBA_fnc_addPerFrameHandler;

--- a/addons/medical/functions/fnc_unconsciousFX.sqf
+++ b/addons/medical/functions/fnc_unconsciousFX.sqf
@@ -33,6 +33,6 @@
     private _heartRate = ace_player getVariable ["ace_medical_heartRate", 80];
     if (random 1 > GVAR(unconsciousFXChance) && _heartRate > 40) then {
         private _moan = selectRandom UNCONSCIOUS_NOISES;
-        [QEGVAR(mission,say3D), [ace_player, _moan]] call CBA_fnc_globalEvent;
+        [QGVAR(say3D), [ace_player, _moan]] call CBA_fnc_globalEvent;
     };
 }, GVAR(unconsciousFXTimer)] call CBA_fnc_addPerFrameHandler;

--- a/addons/medical/functions/fnc_unconsciousFX.sqf
+++ b/addons/medical/functions/fnc_unconsciousFX.sqf
@@ -1,9 +1,9 @@
 #include "..\script_component.hpp"
 /*
  * Author: Mike
- * Handles noises while unconscious
+ * Handles noises while unconscious.
  *
- * Called locally per player via target event
+ * Called locally per player via target event.
  *
  * Arguments
  * None

--- a/addons/medical/initSettings.inc.sqf
+++ b/addons/medical/initSettings.inc.sqf
@@ -10,15 +10,6 @@ private _category = format ["TAC %1", QUOTE(COMPONENT_BEAUTIFIED)];
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(unconsciousFXEnabled),
-    "CHECKBOX",
-    [LSTRING(UnconsciousFX_DisplayName), LSTRING(UnconsciousFX_Description)],
-    _category,
-    true,
-    1
-] call CBA_fnc_addSetting;
-
-[
     QGVAR(unconsciousFXChance),
     "SLIDER",
     [LSTRING(UnconsciousFXChance_DisplayName), LSTRING(UnconsciousFXChance_Description)],

--- a/addons/medical/initSettings.inc.sqf
+++ b/addons/medical/initSettings.inc.sqf
@@ -1,8 +1,37 @@
+private _category = format ["TAC %1", QUOTE(COMPONENT_BEAUTIFIED)];
+
 [
     QGVAR(fatalInjuriesCardiacArrestTimeCoefficient),
     "SLIDER",
     [LSTRING(FatalInjuriesCardiacArrestTimeCoefficient_DisplayName), LSTRING(FatalInjuriesCardiacArrestTimeCoefficient_Description)],
-    format ["TAC %1", QUOTE(COMPONENT_BEAUTIFIED)],
+    _category,
     [0.01, 1, 0.2, 2],
     true // isGlobal
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(unconsciousFXEnabled),
+    "CHECKBOX",
+    [LSTRING(UnconsciousFX_DisplayName), LSTRING(UnconsciousFX_Description)],
+    _category,
+    true,
+    1
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(unconsciousFXChance),
+    "SLIDER",
+    [LSTRING(UnconsciousFXChance_DisplayName), LSTRING(UnconsciousFXChance_Description)],
+    _category,
+    [0, 1, 0.5, 1, true],
+    1
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(unconsciousFXTimer),
+    "SLIDER",
+    [LSTRING(UnconsciousFXTimer_DisplayName), LSTRING(UnconsciousFXTimer_Description)],
+    _category,
+    [5, 60, 30, 1, false],
+    1
 ] call CBA_fnc_addSetting;

--- a/addons/medical/script_component.hpp
+++ b/addons/medical/script_component.hpp
@@ -15,3 +15,6 @@
 #endif
 
 #include "\x\tac\addons\main\script_macros.hpp"
+
+#define KO_NOISES ["ace_fire_scream_12", "ACE_hit_Male05ENG_high_3", "ACE_hit_Male05ENG_high_4", "ACE_hit_Male05ENG_mid_4", "ACE_moan_Male06ENG_high_8"]
+#define UNCONSCIOUS_NOISES ["ace_fire_scream_8", "ACE_moan_Male07ENG_high_2", "ACE_moan_Male07ENG_high_4", "ACE_moan_Male09ENG_high_1", "ACE_moan_Male09ENG_high_2", "ACE_moan_Male09ENG_high_3", "ACE_moan_Male09ENG_high_4"]

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -7,5 +7,23 @@
         <Key ID="STR_TAC_Medical_FatalInjuriesCardiacArrestTimeCoefficient_Description">
             <English>Coefficient for controlling the Cardiac Arrest Time on fatal injuries when 'Fatal Injuries' is NOT 'Always'.</English>
         </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFX_DisplayName">
+            <English>Unconscious Effect Sounds</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFX_Description">
+            <English>Enabled groaning sounds for unconscious players with a heart rate.</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFXChance_DisplayName">
+            <English>Unconscious Effect Sound Chance</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFXChance_Description">
+            <English>The chance of unconscious sounds playing each check.</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFXTimer_DisplayName">
+            <English>Unconscious Effect Timer</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFXTimer_Description">
+            <English>Time interval for checking if the sound effect should play</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -19,11 +19,5 @@
         <Key ID="STR_TAC_Medical_UnconsciousFXTimer_DisplayName">
             <English>Unconscious Effect Timer</English>
         </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFX_Description">
-            <English>Enabled groaning sounds for unconscious players with a heart rate.</English>
-        </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFX_DisplayName">
-            <English>Unconscious Effect Sounds</English>
-        </Key>
     </Package>
 </Project>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TAC">
     <Package name="Medical">
-        <Key ID="STR_TAC_Medical_FatalInjuriesCardiacArrestTimeCoefficient_DisplayName">
-            <English>Fatal Injuries Cardiac Arrest Time Coefficient</English>
-        </Key>
         <Key ID="STR_TAC_Medical_FatalInjuriesCardiacArrestTimeCoefficient_Description">
             <English>Coefficient for controlling the Cardiac Arrest Time on fatal injuries when 'Fatal Injuries' is NOT 'Always'.</English>
         </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFX_DisplayName">
-            <English>Unconscious Effect Sounds</English>
-        </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFX_Description">
-            <English>Enabled groaning sounds for unconscious players with a heart rate.</English>
-        </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFXChance_DisplayName">
-            <English>Unconscious Effect Sound Chance</English>
+        <Key ID="STR_TAC_Medical_FatalInjuriesCardiacArrestTimeCoefficient_DisplayName">
+            <English>Fatal Injuries Cardiac Arrest Time Coefficient</English>
         </Key>
         <Key ID="STR_TAC_Medical_UnconsciousFXChance_Description">
             <English>The chance of unconscious sounds playing each check.</English>
         </Key>
-        <Key ID="STR_TAC_Medical_UnconsciousFXTimer_DisplayName">
-            <English>Unconscious Effect Timer</English>
+        <Key ID="STR_TAC_Medical_UnconsciousFXChance_DisplayName">
+            <English>Unconscious Effect Sound Chance</English>
         </Key>
         <Key ID="STR_TAC_Medical_UnconsciousFXTimer_Description">
             <English>Time interval for checking if the sound effect should play</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFXTimer_DisplayName">
+            <English>Unconscious Effect Timer</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFX_Description">
+            <English>Enabled groaning sounds for unconscious players with a heart rate.</English>
+        </Key>
+        <Key ID="STR_TAC_Medical_UnconsciousFX_DisplayName">
+            <English>Unconscious Effect Sounds</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a screaming sound when you get knocked unconscious
- Percentage of making a groaning sound while you're unconscious (if you have a heart rate above 40, this excludes CPR)
- Uses sounds from ACE.
- Has a chance setting and a timer setting.
    - 50% by default.
    - 30s by default. 
- The groaning check is done locally on the unconscious person, ~~uses the `say3D` event from mission (why its now a requirement)~~.
- PFH is removed when awake, so if you die it goes away.
- Requested by El Presidente.