### PR TITLE
Difficulties - Include RPG Units in Accuracy Factor

### DIFF
--- a/addons/difficulties/XEH_postInit.sqf
+++ b/addons/difficulties/XEH_postInit.sqf
@@ -6,6 +6,20 @@
     if (_vehicle != _unit && {gunner _vehicle == _unit || commander _vehicle == _unit}) then {
         [_unit] call FUNC(setUnitAccuracy);
     };
+
+    // RPG units, no XEH for this EH yet.
+    private _launcherWeapon = secondaryWeapon _unit;
+    if (_launcherWeapon isEqualTo "") exitWith {};
+
+    _unit addEventHandler ["WeaponChanged", {
+        params ["_unit", "_oldWeapon", "_newWeapon"];
+        if (_newWeapon isEqualTo secondaryWeapon _unit) then {
+            [_unit] call FUNC(setUnitAccuracy);
+        } else {
+            [_unit, true] call FUNC(setUnitAccuracy);
+        };
+    }];
+
 }, true, [], true] call CBA_fnc_addClassEventHandler;
 
 private _getInHandler = {

--- a/addons/difficulties/functions/fnc_setUnitAccuracy.sqf
+++ b/addons/difficulties/functions/fnc_setUnitAccuracy.sqf
@@ -24,6 +24,7 @@ if (_reset) exitWith {
     if (!isNil "_originalAccuracy") then {
         _unit setVariable [QGVAR(originalAccuracy), nil, true];
         _unit setSkill ["aimingAccuracy", _originalAccuracy];
+        _unit setSkill ["aimingShake", _originalAccuracy];
     };
 };
 
@@ -31,4 +32,5 @@ if (isNil "_originalAccuracy") then {
     _originalAccuracy = _unit skill "aimingAccuracy";
     _unit setVariable [QGVAR(originalAccuracy), _originalAccuracy, true];
     _unit setSkill ["aimingAccuracy", _originalAccuracy * GVAR(armorAccuracyFactor)];
+    _unit setSkill ["aimingShake", _originalAccuracy * GVAR(armorAccuracyFactor)];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Includes RPG units with the accuracy factor changes
- Aiming shake is also affected (without it RPGs are still pinpoint accurate, shouldn't do anything to vehicles really.)
