### PR TITLE
Debug Console - Fix curator reassignment (backwards logic)

### DIFF
--- a/addons/debug_console/functions/fnc_handleRespawn.sqf
+++ b/addons/debug_console/functions/fnc_handleRespawn.sqf
@@ -27,4 +27,4 @@ private _module = (_moduleData select 0) select 0;
 unassignCurator _module;
 
 // Reassign curator back to original player
-_module assignCurator _newUnit;
+_newUnit assignCurator _module;


### PR DESCRIPTION
**When merged this pull request will:**
- Respawn doesn't reassign curator module because arguments are in the wrong place.
