### PR TITLE
Main - Fix typo to collapse category

### DIFF
--- a/addons/main/CfgEden.hpp
+++ b/addons/main/CfgEden.hpp
@@ -3,7 +3,7 @@ class Cfg3DEN {
         class AttributeCategories {
             class PREFIX {
                 displayName = CSTRING(Attributes);
-                collaped = 1;
+                collapsed = 1;
                 class Attributes {};
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Category was always expanded, wondered why and now I know!
