### PR TITLE
Fire Support - Add only targeting perimeter setting

### DIFF
--- a/addons/firesupport/README.md
+++ b/addons/firesupport/README.md
@@ -9,6 +9,7 @@ Firesupport must be enabled via CBA settings, as is the delay and ensure that AC
 force ace_mk6mortar_useAmmoHandling = false;
 force tac_firesupport_enabled = true;
 force tac_firesupport_delay = 30;
+force tac_firesupport_perimeterImpact = false;
 ```
 
 All variables should be added to `init.sqf`

--- a/addons/firesupport/functions/fnc_mortarSupport.sqf
+++ b/addons/firesupport/functions/fnc_mortarSupport.sqf
@@ -54,7 +54,7 @@ _marker setMarkerSizeLocal GVAR(areaSize);
     params ["_mortarInRange", "_marker", "_inRange", "_unit"];
 
     // Fire Mortars
-    private _mortarFired = ([_mortarInRange, [_marker], GVAR(roundCount), 0] call tac_mission_fnc_mortarStrike) params ["_eta", "_rounds"];
+    private _mortarFired = ([_mortarInRange, [_marker], GVAR(roundCount), 0, GVAR(perimeterImpact)] call tac_mission_fnc_mortarStrike) params ["_eta", "_rounds"];
 
     private _teamName = format ["%1", _mortarInRange getVariable [QGVAR(mortarName), "Templar"]];
     private _etaText = format ["Fire for effect, %1 rounds incoming, ETA %2 seconds to target.", _rounds, _eta];

--- a/addons/firesupport/initSettings.inc.sqf
+++ b/addons/firesupport/initSettings.inc.sqf
@@ -17,3 +17,12 @@ private _category = format ["TAC %1", QUOTE(COMPONENT_BEAUTIFIED)];
     [0, 1800, 30],
     true
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(perimeterImpact),
+    "CHECKBOX",
+    [LSTRING(perimeterDisplay), LSTRING(perimeterDescription)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;

--- a/addons/firesupport/stringtable.xml
+++ b/addons/firesupport/stringtable.xml
@@ -10,5 +10,11 @@
         <Key ID="STR_TAC_Firesupport_delayDisplay">
             <English>Delay between fire support</English>
         </Key>
+        <Key ID="STR_TAC_Firesupport_perimeterDisplay">
+            <English>Rounds impact on perimeter</English>
+        </Key>
+        <Key ID="STR_TAC_Firesupport_perimeterDescription">
+            <English>Should rounds only land on the perimeter of the area marked for mortar strikes</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/mission/functions/fnc_mortarStrike.sqf
+++ b/addons/mission/functions/fnc_mortarStrike.sqf
@@ -4,6 +4,7 @@
  * Orders mortars to fire on an area. Each round will be fired at a different point on a random marker provided.
  * If amount is 0 then it will choose randomly between 1-8.
  * Ammo types are: HE (0), Smoke (1), Illumination (2)
+ * Only impact perimeter will force rounds to land on the outside of the total area fired on.
  * This function also covers the CUP D30 Artillery.
  *
  * Call on the server.
@@ -13,6 +14,7 @@
  * 1: Marker Array <ARRAY>
  * 2: Rounds to fire <NUMBER>
  * 3: Ammo Type <NUMBER>
+ * 4: Only impact perimeter <BOOL>
  *
  * Return Value:
  * 0: ETA (seconds) <NUMBER>
@@ -23,7 +25,7 @@
  * [My_Mortar, GVAR(markerArray)] call MFUNC(mortarStrike)
  */
 
-params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0]];
+params ["_mortar", "_markersArray", ["_amount", 0], ["_ammoType", 0], ["_onlyImpactPerimeter", true]];
 
 if (!isServer) exitWith {};
 
@@ -72,7 +74,7 @@ if (is3DENPreview) then {
 
 for "_i" from 0 to _amount - 1 do {
     private _marker = selectRandom _markersArray;
-    private _position = [_marker, true] call CBA_fnc_randPosArea;
+    private _position = [_marker, _onlyImpactPerimeter] call CBA_fnc_randPosArea;
     _eta = round (_mortar getArtilleryETA [_position, _ammo]);
     [{
         params ["_mortar", "_position", "_ammo", "_gunner"];


### PR DESCRIPTION
**When merged this pull request will:**
- Before this rounds from `mortarStrike` would only ever land on the perimeter of the target area. Firesupport would make more sense to not do this so now it's optional.
